### PR TITLE
Replace spotify/apple music links with coming soon label

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,32 @@ Edit the JSON files under `data/`:
 - `data/members.json` - band member cards
 - `data/media.json` - past show photos/videos
 
+### Streaming links (Spotify / Apple Music)
+
+Streaming buttons are driven by `data/band.json` → `streaming`.
+
+- To show a clickable button, set the value to a URL string:
+
+```json
+{
+  "streaming": {
+    "spotify": "https://open.spotify.com/artist/REAL_ID",
+    "appleMusic": "https://music.apple.com/artist/REAL_ID"
+  }
+}
+```
+
+- To show a non-clickable "Coming Soon" label, set the value to:
+
+```json
+{
+  "streaming": {
+    "spotify": { "status": "coming-soon" },
+    "appleMusic": { "status": "coming-soon" }
+  }
+}
+```
+
 ## Images and media
 
 Place images in `public/images/` and reference them by absolute path in JSON, e.g.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,6 +16,9 @@ export default function HomePage() {
   const band = getBand();
   const shows = getShows();
   const upcoming = shows.upcoming.slice(0, 3);
+  const spotifyLink = band.streaming.spotify;
+  const isSpotifyUrl = (link: typeof spotifyLink): link is string =>
+    typeof link === "string";
 
   return (
     <div>
@@ -29,14 +32,20 @@ export default function HomePage() {
               {band.tagline}
             </p>
             <div className="mt-8 flex flex-wrap gap-4">
-              <Link
-                href={band.streaming.spotify}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center justify-center rounded-full border border-accent bg-accent px-6 py-3 text-xs font-semibold uppercase tracking-[0.2em] text-white transition hover:shadow-glow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-              >
-                Listen
-              </Link>
+              {isSpotifyUrl(spotifyLink) ? (
+                <Link
+                  href={spotifyLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center justify-center rounded-full border border-accent bg-accent px-6 py-3 text-xs font-semibold uppercase tracking-[0.2em] text-white transition hover:shadow-glow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                >
+                  Listen
+                </Link>
+              ) : (
+                <span className="inline-flex items-center justify-center rounded-full border border-accent bg-accent px-6 py-3 text-xs font-semibold uppercase tracking-[0.2em] text-white">
+                  Coming Soon
+                </span>
+              )}
               <Link
                 href="/shows"
                 className="inline-flex items-center justify-center rounded-full border border-black/10 px-6 py-3 text-xs font-semibold uppercase tracking-[0.2em] text-ink-800 transition hover:border-black/30 hover:text-ink-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"

--- a/components/StreamingLinks.tsx
+++ b/components/StreamingLinks.tsx
@@ -1,30 +1,57 @@
 import Link from "next/link";
+import type { StreamingLink } from "@/lib/types";
 
 export default function StreamingLinks({
   spotify,
   appleMusic
 }: {
-  spotify: string;
-  appleMusic: string;
+  spotify: StreamingLink;
+  appleMusic: StreamingLink;
 }) {
+  const isUrl = (link: StreamingLink): link is string =>
+    typeof link === "string";
+  const spotifyIsUrl = isUrl(spotify);
+  const appleIsUrl = isUrl(appleMusic);
+  const allComingSoon = !spotifyIsUrl && !appleIsUrl;
+
   return (
     <div className="flex flex-wrap gap-4">
-      <Link
-        href={spotify}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="inline-flex items-center justify-center rounded-full border border-accent bg-accent px-6 py-3 text-xs font-semibold uppercase tracking-[0.2em] text-white transition hover:shadow-glow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-      >
-        Listen on Spotify
-      </Link>
-      <Link
-        href={appleMusic}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="inline-flex items-center justify-center rounded-full border border-black/10 px-6 py-3 text-xs font-semibold uppercase tracking-[0.2em] text-ink-800 transition hover:border-black/20 hover:text-ink-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-      >
-        Apple Music
-      </Link>
+      {allComingSoon ? (
+        <span className="inline-flex items-center justify-center rounded-full border border-accent bg-accent px-6 py-3 text-xs font-semibold uppercase tracking-[0.2em] text-white">
+          Coming Soon
+        </span>
+      ) : (
+        <>
+          {spotifyIsUrl ? (
+            <Link
+              href={spotify}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center justify-center rounded-full border border-accent bg-accent px-6 py-3 text-xs font-semibold uppercase tracking-[0.2em] text-white transition hover:shadow-glow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              Listen on Spotify
+            </Link>
+          ) : (
+            <span className="inline-flex items-center justify-center rounded-full border border-accent bg-accent px-6 py-3 text-xs font-semibold uppercase tracking-[0.2em] text-white">
+              Coming Soon
+            </span>
+          )}
+          {appleIsUrl ? (
+            <Link
+              href={appleMusic}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center justify-center rounded-full border border-black/10 px-6 py-3 text-xs font-semibold uppercase tracking-[0.2em] text-ink-800 transition hover:border-black/20 hover:text-ink-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              Apple Music
+            </Link>
+          ) : (
+            <span className="inline-flex items-center justify-center rounded-full border border-black/10 px-6 py-3 text-xs font-semibold uppercase tracking-[0.2em] text-ink-800">
+              Coming Soon
+            </span>
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/data/band.json
+++ b/data/band.json
@@ -10,7 +10,11 @@
     "youtube": "https://youtube.com/@sweetside"
   },
   "streaming": {
-    "spotify": "https://open.spotify.com/artist/placeholder",
-    "appleMusic": "https://music.apple.com/artist/placeholder"
+    "spotify": {
+      "status": "coming-soon"
+    },
+    "appleMusic": {
+      "status": "coming-soon"
+    }
   }
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,3 +1,5 @@
+export type StreamingLink = string | { status: "coming-soon" };
+
 export type Band = {
   name: string;
   tagline: string;
@@ -11,8 +13,8 @@ export type Band = {
     bandcamp?: string;
   };
   streaming: {
-    spotify: string;
-    appleMusic: string;
+    spotify: StreamingLink;
+    appleMusic: StreamingLink;
   };
 };
 


### PR DESCRIPTION
- Switch streaming entries in data/band.json to status-based coming-soon
- Render a single non-clickable "Coming Soon" label in StreamingLinks
- Update home hero Listen CTA to be non-clickable when Spotify is coming soon
- Update types to support string URL or coming-soon status
- Document how to enable real streaming links in README