### PR TITLE
Fix linter problems

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -46,9 +46,11 @@ export default function HomePage() {
 
       <section className="relative z-10 min-h-[calc(100vh-var(--nav-height,0px))] min-h-[calc(100svh-var(--nav-height,0px))]">
         <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-4 px-6 text-center sm:gap-6">
-          <img
+          <Image
             src="/sweetside_white.svg"
             alt={band.name}
+            width={354}
+            height={92}
             className="w-56 max-w-[85vw] drop-shadow-2xl sm:w-72 md:w-[26rem] lg:w-[32rem]"
           />
           <div className="flex flex-wrap justify-center gap-4">

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import type { Band } from "@/lib/types";
 import SocialLinks from "@/components/SocialLinks";
 
@@ -6,9 +7,11 @@ export default function Footer({ band }: { band: Band }) {
     <footer className="border-t border-black/10 bg-accent text-paper">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 py-10 md:flex-row md:items-center md:justify-between">
         <div>
-          <img
+          <Image
             src="/sweetside_white.svg"
             alt="Sweetside"
+            width={354}
+            height={92}
             className="h-7 w-auto"
           />
           <p className="mt-2 text-sm">

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import type { MouseEvent } from "react";
@@ -116,9 +117,11 @@ export default function Navbar({ band }: { band: Band }) {
             className={logoLinkClassName}
             onClick={handleHomeClick}
           >
-            <img
+            <Image
               src={logoSrc}
               alt="Sweetside"
+              width={354}
+              height={92}
               className="h-8 w-auto -mt-1.5"
             />
           </Link>

--- a/components/PhotoSlideshow.tsx
+++ b/components/PhotoSlideshow.tsx
@@ -83,13 +83,13 @@ export default function PhotoSlideshow({ items }: PhotoSlideshowProps) {
     };
   }, [isLightboxOpen, totalItems]);
 
-  if (totalItems === 0) {
-    return null;
-  }
-
-  const activeItem = items[activeIndex];
+  const activeItem = totalItems > 0 ? (items[activeIndex] ?? items[0]) : null;
 
   useEffect(() => {
+    if (!activeItem?.src) {
+      return;
+    }
+
     let isMounted = true;
     const image = new window.Image();
 
@@ -115,7 +115,11 @@ export default function PhotoSlideshow({ items }: PhotoSlideshowProps) {
     return () => {
       isMounted = false;
     };
-  }, [activeItem.src]);
+  }, [activeItem?.src]);
+
+  if (!activeItem) {
+    return null;
+  }
 
   const handlePointerDown = (event: PointerEvent<HTMLElement>) => {
     pointerStartX.current = event.clientX;

--- a/components/StreamingLinks.tsx
+++ b/components/StreamingLinks.tsx
@@ -27,14 +27,14 @@ export default function StreamingLinks({
           <SpotifyIcon className="h-5 w-5" />
         </Link>
       ) : (
-        <span
-          aria-label="Spotify (Coming soon)"
-          aria-disabled="true"
-          role="img"
+        <button
+          type="button"
+          disabled
           className="inline-flex cursor-not-allowed items-center justify-center rounded-full border border-accent bg-accent px-6 py-3 text-white opacity-40"
         >
-          <SpotifyIcon className="h-5 w-5" />
-        </span>
+          <SpotifyIcon aria-hidden="true" className="h-5 w-5" />
+          <span className="sr-only">Spotify (Coming soon)</span>
+        </button>
       )}
       {appleUrl ? (
         <Link
@@ -47,14 +47,14 @@ export default function StreamingLinks({
           <AppleMusicIcon className="h-5 w-5" />
         </Link>
       ) : (
-        <span
-          aria-label="Apple Music (Coming soon)"
-          aria-disabled="true"
-          role="img"
+        <button
+          type="button"
+          disabled
           className="inline-flex cursor-not-allowed items-center justify-center rounded-full border border-black/10 px-6 py-3 text-ink-800 opacity-40"
         >
-          <AppleMusicIcon className="h-5 w-5" />
-        </span>
+          <AppleMusicIcon aria-hidden="true" className="h-5 w-5" />
+          <span className="sr-only">Apple Music (Coming soon)</span>
+        </button>
       )}
     </div>
   );


### PR DESCRIPTION
- Replaced logo `<img>` with Next `<Image />` (with `width={354}` and `height={92}`) in:
  - `app/page.tsx`
  - `components/Footer.tsx`
  - `components/Navbar.tsx`
- Added `import Image from "next/image";` where needed:
  - `components/Footer.tsx`
  - `components/Navbar.tsx`
- Refactored hooks in `components/PhotoSlideshow.tsx` so hooks are unconditional and early return happens after effects; added safe `activeItem` handling to avoid `items[activeIndex]` access when empty.
- Reworked “Coming soon” placeholders in `components/StreamingLinks.tsx` to disabled `button` elements with accessible names via `sr-only`, and marked icons as `aria-hidden`.
- Verified `npm run lint` reports `0 problems` (no warnings, no errors).