### PR TITLE
add SQLite-backed photo gallery image management to the admin dashboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 ## Project Purpose
 - This repository powers the public website for the band **Sweetside**.
 - Primary goals: show upcoming/past shows, media gallery, streaming links, merch placeholder, and booking contact.
-- Band/member/media content is file-driven, while shows are stored in SQLite.
+- Band/member/video media content is file-driven, while shows and photo gallery images are stored in SQLite.
 
 ## Tech Stack
 - **Next.js 16** (App Router) + **React 18** + **TypeScript (strict)**.
@@ -55,7 +55,7 @@
 - Show data is loaded from SQLite through `lib/shows-db.ts`.
 - Upcoming show records may include optional `venue_url`, `tickets_url`, time, fee, address, and poster fields.
 - Public show lists are sorted by date descending within `upcoming` and `past`.
-- Show photos for `/video/photos` are loaded from `public/images/shows/` (filesystem scan), not from JSON.
+- Show photos for `/video/photos` are loaded from the SQLite-backed admin gallery, not from JSON or `public/images/shows/`.
 - Components/pages rely on these TypeScript types in `lib/types.ts`.
 
 ## Data Files: What They Drive
@@ -66,16 +66,18 @@
 - `data/media.json`:
   - video items for the `/video` gallery page.
 - `data/shows.sqlite`:
-  - local default SQLite database for shows during non-Docker development.
+  - local default SQLite database for shows and photo gallery images during non-Docker development.
   - upcoming rows may include `tickets_url` for the public Tickets button.
 - `storage/posters/`:
   - local default writable poster storage outside `public/`.
 - Docker volume storage:
   - `/app/storage/shows.sqlite`
   - `/app/storage/posters/`
-- `public/images/shows/`:
-  - source of truth for the `/video/photos` masonry gallery.
-  - all supported image files in this folder are included automatically and shuffled during build/static generation.
+- Photo gallery images:
+  - source of truth is the `gallery_images` table in SQLite.
+  - public images are served through `/gallery-images/[fileName]`.
+  - admin uploads accept `.jpg` and `.jpeg` files only, 1 MB max each.
+  - gallery records are shuffled during build/static generation.
 
 ## Streaming Link Rules
 - `spotify`/`appleMusic` accept:
@@ -96,6 +98,7 @@
   - Pill-style `Video`/`Photo` selector shared by gallery subpages.
 - `components/PhotoMasonryGrid.tsx`:
   - Adaptive masonry photo layout + in-page lightbox interaction.
+  - Receives database-backed image media from `getShowPhotos()`.
 - `components/MediaGrid.tsx`:
   - Video card grid used on the default gallery route.
 - `components/ContactSection.tsx`:
@@ -167,7 +170,7 @@
 1. Read `README.md` and this file.
 2. Check `data/*.json` for the latest real content before making assumptions.
 3. If content-only change: edit JSON + ensure referenced files exist in `public/images/...`.
-   For show photos specifically, add/remove files in `public/images/shows/` instead of editing `data/media.json`.
+   For show photos specifically, use the admin Images tab instead of editing `data/media.json` or adding files to `public/images/shows/`.
    For show listings, inspect the admin flow and SQLite helpers.
    For show posters, inspect `lib/show-posters.ts` and the `/posters/[fileName]` route instead of `public/`.
 4. If UI change: inspect the specific page in `app/` and related component(s) in `components/`.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ When Spotify is set to a supported Spotify URL (`artist`, `album`, `track`, `pla
 
 ## Images and media
 
-Photos on `/video/photos` are loaded automatically from `public/images/shows/` and shuffled during site build/static generation (not on every request).
+Photos on `/video/photos` are loaded from the SQLite-backed admin gallery and shuffled during site build/static generation (not on every request). Use `/admin` → `Images` to upload or delete gallery photos.
 
 Place other images in `public/images/` and reference them by absolute path in JSON, e.g.
 
@@ -126,6 +126,8 @@ The admin dashboard lets you:
 - add and delete shows
 - upload PNG posters only
 - upload posters up to 5 MB each, with a 20 MB combined upload cap per sync
+- upload and delete photo gallery images
+- upload photo gallery images as `.jpg` or `.jpeg` files up to 1 MB each
 - sync the draft state and revalidate `/` and `/shows`
 
 Admin API protection:
@@ -133,3 +135,4 @@ Admin API protection:
 - login and sync endpoints use an in-memory process-wide rate limiter
 - logout clears the admin session cookie server-side and the client navigates directly to `/admin/login`
 - sync validates poster extension, PNG file signature, upload size limits, and show writes in the same request
+- gallery image uploads validate extension, JPEG file signature, and upload size before storing image bytes in SQLite

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,20 +1,21 @@
 import AdminDashboard from "@/components/admin/AdminDashboard";
 import AdminLogoutButton from "@/components/admin/AdminLogoutButton";
 import { requireAdminAuthentication } from "@/lib/admin-auth";
-import { getManagedShows } from "@/lib/shows-db";
+import { getManagedGalleryImages, getManagedShows } from "@/lib/shows-db";
 
 export const dynamic = "force-dynamic";
 
 export default async function AdminPage() {
   await requireAdminAuthentication();
   const shows = getManagedShows();
+  const images = getManagedGalleryImages();
 
   return (
     <div className="relative">
       <div className="absolute right-6 top-6 z-10">
         <AdminLogoutButton />
       </div>
-      <AdminDashboard initialShows={shows} />
+      <AdminDashboard initialShows={shows} initialImages={images} />
     </div>
   );
 }

--- a/app/api/admin/gallery-images/route.ts
+++ b/app/api/admin/gallery-images/route.ts
@@ -3,10 +3,8 @@ import { NextResponse } from "next/server";
 import { ADMIN_COOKIE_NAME, verifyAdminSessionToken } from "@/lib/admin-auth";
 import {
   removeGalleryImage,
-  saveGalleryImageUpload,
-  validateGalleryImageUpload
+  saveGalleryImageUploads
 } from "@/lib/admin-gallery-images";
-import { getManagedGalleryImages } from "@/lib/shows-db";
 import {
   ADMIN_SYNC_RATE_LIMIT,
   applyRateLimitHeaders,
@@ -57,19 +55,13 @@ export async function POST(request: Request) {
       }))
     );
 
-    for (const upload of uploads) {
-      validateGalleryImageUpload(upload);
-    }
-
-    for (const upload of uploads) {
-      await saveGalleryImageUpload(upload);
-    }
+    const images = saveGalleryImageUploads(uploads);
 
     revalidatePath("/video/photos");
     revalidatePath("/admin");
 
     return applyRateLimitHeaders(
-      NextResponse.json({ images: getManagedGalleryImages() }),
+      NextResponse.json({ images }),
       rateLimit.result
     );
   } catch (error) {

--- a/app/api/admin/gallery-images/route.ts
+++ b/app/api/admin/gallery-images/route.ts
@@ -1,0 +1,121 @@
+import { revalidatePath } from "next/cache";
+import { NextResponse } from "next/server";
+import { ADMIN_COOKIE_NAME, verifyAdminSessionToken } from "@/lib/admin-auth";
+import {
+  removeGalleryImage,
+  saveGalleryImageUpload,
+  validateGalleryImageUpload
+} from "@/lib/admin-gallery-images";
+import { getManagedGalleryImages } from "@/lib/shows-db";
+import {
+  ADMIN_SYNC_RATE_LIMIT,
+  applyRateLimitHeaders,
+  enforceRateLimit
+} from "@/lib/rate-limit";
+
+export const runtime = "nodejs";
+
+function isAuthenticated(request: Request) {
+  const tokenMatch = request.headers
+    .get("cookie")
+    ?.match(new RegExp(`(?:^|;\\s*)${ADMIN_COOKIE_NAME}=([^;]+)`));
+
+  return verifyAdminSessionToken(tokenMatch?.[1]);
+}
+
+function unauthorized(rateLimit: ReturnType<typeof enforceRateLimit>) {
+  return applyRateLimitHeaders(
+    NextResponse.json({ error: "Unauthorized." }, { status: 401 }),
+    rateLimit.result
+  );
+}
+
+export async function POST(request: Request) {
+  const rateLimit = enforceRateLimit(ADMIN_SYNC_RATE_LIMIT);
+  if (rateLimit.limited) {
+    return rateLimit.response;
+  }
+
+  if (!isAuthenticated(request)) {
+    return unauthorized(rateLimit);
+  }
+
+  try {
+    const formData = await request.formData();
+    const files = formData
+      .getAll("images")
+      .filter((value): value is File => value instanceof File);
+
+    if (files.length === 0) {
+      throw new Error("Choose at least one JPEG image to upload.");
+    }
+
+    const uploads = await Promise.all(
+      files.map(async (file) => ({
+        fileName: file.name,
+        bytes: new Uint8Array(await file.arrayBuffer())
+      }))
+    );
+
+    for (const upload of uploads) {
+      validateGalleryImageUpload(upload);
+    }
+
+    for (const upload of uploads) {
+      await saveGalleryImageUpload(upload);
+    }
+
+    revalidatePath("/video/photos");
+    revalidatePath("/admin");
+
+    return applyRateLimitHeaders(
+      NextResponse.json({ images: getManagedGalleryImages() }),
+      rateLimit.result
+    );
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unable to upload gallery image.";
+
+    return applyRateLimitHeaders(
+      NextResponse.json({ error: message }, { status: 400 }),
+      rateLimit.result
+    );
+  }
+}
+
+export async function DELETE(request: Request) {
+  const rateLimit = enforceRateLimit(ADMIN_SYNC_RATE_LIMIT);
+  if (rateLimit.limited) {
+    return rateLimit.response;
+  }
+
+  if (!isAuthenticated(request)) {
+    return unauthorized(rateLimit);
+  }
+
+  try {
+    const payload = (await request.json()) as { id?: unknown };
+
+    if (typeof payload.id !== "string") {
+      throw new Error("Image ID is required.");
+    }
+
+    const images = removeGalleryImage(payload.id);
+
+    revalidatePath("/video/photos");
+    revalidatePath("/admin");
+
+    return applyRateLimitHeaders(
+      NextResponse.json({ images }),
+      rateLimit.result
+    );
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unable to delete gallery image.";
+
+    return applyRateLimitHeaders(
+      NextResponse.json({ error: message }, { status: 400 }),
+      rateLimit.result
+    );
+  }
+}

--- a/app/gallery-images/[fileName]/route.ts
+++ b/app/gallery-images/[fileName]/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { readGalleryImage } from "@/lib/shows-db";
+
+export const runtime = "nodejs";
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ fileName: string }> }
+) {
+  const { fileName } = await context.params;
+  const galleryImage = readGalleryImage(fileName);
+
+  if (!galleryImage) {
+    return new NextResponse("Not found.", { status: 404 });
+  }
+
+  return new NextResponse(new Uint8Array(galleryImage.content), {
+    headers: {
+      "Content-Type": galleryImage.image.mimeType,
+      "Cache-Control": "public, max-age=31536000, immutable"
+    }
+  });
+}

--- a/components/admin/AdminDashboard.tsx
+++ b/components/admin/AdminDashboard.tsx
@@ -538,38 +538,7 @@ export default function AdminDashboard({
               </div>
             </section>
           </div>
-          ) : (
-            <div className="mt-6 space-y-5">
-              <label className="flex cursor-pointer flex-col items-center justify-center rounded-[1.5rem] border border-dashed border-accent/50 bg-white px-5 py-8 text-center transition hover:border-accent hover:bg-haze/40">
-                <span className="text-sm font-semibold uppercase tracking-[0.2em] text-accent">
-                  {isUploadingImages ? "Uploading..." : "Upload JPEG"}
-                </span>
-                <span className="mt-2 text-sm text-ink-600">
-                  .jpg or .jpeg, 1 MB max each
-                </span>
-                <input
-                  type="file"
-                  accept=".jpg,.jpeg,image/jpeg"
-                  multiple
-                  disabled={isUploadingImages}
-                  className="sr-only"
-                  onChange={(event) => {
-                    uploadGalleryImages(event.target.files);
-                    event.currentTarget.value = "";
-                  }}
-                />
-              </label>
-              <div className="space-y-2">
-                <div className="rounded-[1.5rem] border border-dashed border-black/10 px-4 py-8 text-center text-sm text-ink-500">
-                  {images.length > 0
-                    ? `${images.length} gallery image${
-                        images.length === 1 ? "" : "s"
-                      } uploaded.`
-                    : "No gallery images uploaded yet."}
-                </div>
-              </div>
-            </div>
-          )}
+          ) : null}
         </aside>
         {activeTab === "images" ? (
           <section className="rounded-[2rem] border border-black/10 bg-paper p-6 shadow-sm">

--- a/components/admin/AdminDashboard.tsx
+++ b/components/admin/AdminDashboard.tsx
@@ -560,35 +560,13 @@ export default function AdminDashboard({
                 />
               </label>
               <div className="space-y-2">
-                {images.length > 0 ? (
-                  images.map((image) => (
-                    <div
-                      key={image.id}
-                      className="overflow-hidden rounded-2xl border border-black/10 bg-white"
-                    >
-                      <Image
-                        src={image.src}
-                        alt={image.title}
-                        width={640}
-                        height={480}
-                        unoptimized
-                        className="h-36 w-full object-cover"
-                      />
-                      <div className="p-4">
-                        <p className="font-semibold text-ink-900">
-                          {image.title}
-                        </p>
-                        <p className="mt-1 text-xs uppercase tracking-[0.16em] text-ink-500">
-                          {formatByteSize(image.byteSize)}
-                        </p>
-                      </div>
-                    </div>
-                  ))
-                ) : (
-                  <div className="rounded-[1.5rem] border border-dashed border-black/10 px-4 py-8 text-center text-sm text-ink-500">
-                    No gallery images uploaded yet.
-                  </div>
-                )}
+                <div className="rounded-[1.5rem] border border-dashed border-black/10 px-4 py-8 text-center text-sm text-ink-500">
+                  {images.length > 0
+                    ? `${images.length} gallery image${
+                        images.length === 1 ? "" : "s"
+                      } uploaded.`
+                    : "No gallery images uploaded yet."}
+                </div>
               </div>
             </div>
           )}

--- a/components/admin/AdminDashboard.tsx
+++ b/components/admin/AdminDashboard.tsx
@@ -3,7 +3,7 @@
 import Image from "next/image";
 import { useMemo, useRef, useState, startTransition } from "react";
 import { useRouter } from "next/navigation";
-import type { ManagedShow, ShowBucket } from "@/lib/types";
+import type { GalleryImage, ManagedShow, ShowBucket } from "@/lib/types";
 import { deriveShowId } from "@/lib/show-id";
 
 type EditableShow = ManagedShow & {
@@ -13,12 +13,18 @@ type EditableShow = ManagedShow & {
   pendingPosterName: string | null;
 };
 
+type AdminTab = "shows" | "images";
+
 function createClientKey() {
   if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
     return crypto.randomUUID();
   }
 
   return `show-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function formatByteSize(byteSize: number) {
+  return `${(byteSize / 1024).toFixed(0)} KB`;
 }
 
 function toEditableShow(show: ManagedShow): EditableShow {
@@ -61,13 +67,16 @@ function createBlankShow(bucket: ShowBucket): EditableShow {
 }
 
 export default function AdminDashboard({
-  initialShows
+  initialShows,
+  initialImages
 }: {
   initialShows: ManagedShow[];
+  initialImages: GalleryImage[];
 }) {
   const router = useRouter();
   const initialStateRef = useRef<{
     shows: EditableShow[];
+    images: GalleryImage[];
     selectedKey: string | null;
   } | null>(null);
 
@@ -75,15 +84,22 @@ export default function AdminDashboard({
     const preparedShows = initialShows.map(toEditableShow);
     initialStateRef.current = {
       shows: preparedShows,
+      images: initialImages,
       selectedKey: preparedShows[0]?.clientKey ?? null
     };
   }
 
   const [shows, setShows] = useState(initialStateRef.current.shows);
+  const [images, setImages] = useState(initialStateRef.current.images);
   const [selectedKey, setSelectedKey] = useState(initialStateRef.current.selectedKey);
+  const [activeTab, setActiveTab] = useState<AdminTab>("shows");
   const [feedback, setFeedback] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isSyncing, setIsSyncing] = useState(false);
+  const [imageFeedback, setImageFeedback] = useState<string | null>(null);
+  const [imageError, setImageError] = useState<string | null>(null);
+  const [isUploadingImages, setIsUploadingImages] = useState(false);
+  const [deletingImageId, setDeletingImageId] = useState<string | null>(null);
 
   const selectedShow = useMemo(
     () => shows.find((show) => show.clientKey === selectedKey) ?? null,
@@ -100,10 +116,19 @@ export default function AdminDashboard({
   );
 
   const selectShow = (clientKey: string) => {
+    setActiveTab("shows");
     setSelectedKey(clientKey);
     setFeedback(null);
     setError(null);
     window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  const selectTab = (tab: AdminTab) => {
+    setActiveTab(tab);
+    setFeedback(null);
+    setError(null);
+    setImageFeedback(null);
+    setImageError(null);
   };
 
   const updateShow = (clientKey: string, field: keyof EditableShow, value: string) => {
@@ -306,6 +331,104 @@ export default function AdminDashboard({
     })();
   };
 
+  const uploadGalleryImages = (fileList: FileList | null) => {
+    const files = Array.from(fileList ?? []);
+
+    setImageFeedback(null);
+    setImageError(null);
+
+    if (files.length === 0) {
+      return;
+    }
+
+    for (const file of files) {
+      const lowerName = file.name.toLowerCase();
+
+      if (!lowerName.endsWith(".jpg") && !lowerName.endsWith(".jpeg")) {
+        setImageError("Gallery images must use the .jpg or .jpeg extension.");
+        return;
+      }
+
+      if (file.size > 1024 * 1024) {
+        setImageError("Each gallery image must be 1 MB or smaller.");
+        return;
+      }
+    }
+
+    setIsUploadingImages(true);
+
+    void (async () => {
+      const formData = new FormData();
+
+      for (const file of files) {
+        formData.append("images", file);
+      }
+
+      try {
+        const response = await fetch("/api/admin/gallery-images", {
+          method: "POST",
+          body: formData
+        });
+        const result = (await response.json()) as {
+          error?: string;
+          images?: GalleryImage[];
+        };
+
+        if (!response.ok || !result.images) {
+          setImageError(result.error ?? "Image upload failed.");
+          return;
+        }
+
+        setImages(result.images);
+        setImageFeedback("Image upload complete. Photo gallery will refresh on the next request.");
+        startTransition(() => {
+          router.refresh();
+        });
+      } catch {
+        setImageError("Image upload failed.");
+      } finally {
+        setIsUploadingImages(false);
+      }
+    })();
+  };
+
+  const deleteGalleryImage = (imageId: string) => {
+    setImageFeedback(null);
+    setImageError(null);
+    setDeletingImageId(imageId);
+
+    void (async () => {
+      try {
+        const response = await fetch("/api/admin/gallery-images", {
+          method: "DELETE",
+          headers: {
+            "Content-Type": "application/json"
+          },
+          body: JSON.stringify({ id: imageId })
+        });
+        const result = (await response.json()) as {
+          error?: string;
+          images?: GalleryImage[];
+        };
+
+        if (!response.ok || !result.images) {
+          setImageError(result.error ?? "Image delete failed.");
+          return;
+        }
+
+        setImages(result.images);
+        setImageFeedback("Image deleted. Photo gallery will refresh on the next request.");
+        startTransition(() => {
+          router.refresh();
+        });
+      } catch {
+        setImageError("Image delete failed.");
+      } finally {
+        setDeletingImageId(null);
+      }
+    })();
+  };
+
   return (
     <div className="min-h-screen bg-haze/40">
       <div className="mx-auto grid min-h-screen w-full max-w-[112rem] gap-8 px-6 py-8 lg:grid-cols-[24rem_minmax(0,1fr)]">
@@ -316,10 +439,27 @@ export default function AdminDashboard({
                 Admin
               </p>
               <h1 className="mt-2 font-display text-5xl uppercase text-ink-900">
-                Shows
+                Dashboard
               </h1>
             </div>
           </div>
+          <div className="mt-6 grid grid-cols-2 gap-2 rounded-full border border-black/10 bg-white p-1">
+            {(["shows", "images"] as const).map((tab) => (
+              <button
+                key={tab}
+                type="button"
+                onClick={() => selectTab(tab)}
+                className={`rounded-full px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] transition ${
+                  activeTab === tab
+                    ? "bg-accent text-white shadow-glow"
+                    : "text-ink-600 hover:bg-haze"
+                }`}
+              >
+                {tab}
+              </button>
+            ))}
+          </div>
+          {activeTab === "shows" ? (
           <div className="mt-6 space-y-6">
             <section className="space-y-3">
               <div className="flex items-center justify-between">
@@ -398,7 +538,146 @@ export default function AdminDashboard({
               </div>
             </section>
           </div>
+          ) : (
+            <div className="mt-6 space-y-5">
+              <label className="flex cursor-pointer flex-col items-center justify-center rounded-[1.5rem] border border-dashed border-accent/50 bg-white px-5 py-8 text-center transition hover:border-accent hover:bg-haze/40">
+                <span className="text-sm font-semibold uppercase tracking-[0.2em] text-accent">
+                  {isUploadingImages ? "Uploading..." : "Upload JPEG"}
+                </span>
+                <span className="mt-2 text-sm text-ink-600">
+                  .jpg or .jpeg, 1 MB max each
+                </span>
+                <input
+                  type="file"
+                  accept=".jpg,.jpeg,image/jpeg"
+                  multiple
+                  disabled={isUploadingImages}
+                  className="sr-only"
+                  onChange={(event) => {
+                    uploadGalleryImages(event.target.files);
+                    event.currentTarget.value = "";
+                  }}
+                />
+              </label>
+              <div className="space-y-2">
+                {images.length > 0 ? (
+                  images.map((image) => (
+                    <div
+                      key={image.id}
+                      className="overflow-hidden rounded-2xl border border-black/10 bg-white"
+                    >
+                      <Image
+                        src={image.src}
+                        alt={image.title}
+                        width={640}
+                        height={480}
+                        unoptimized
+                        className="h-36 w-full object-cover"
+                      />
+                      <div className="p-4">
+                        <p className="font-semibold text-ink-900">
+                          {image.title}
+                        </p>
+                        <p className="mt-1 text-xs uppercase tracking-[0.16em] text-ink-500">
+                          {formatByteSize(image.byteSize)}
+                        </p>
+                      </div>
+                    </div>
+                  ))
+                ) : (
+                  <div className="rounded-[1.5rem] border border-dashed border-black/10 px-4 py-8 text-center text-sm text-ink-500">
+                    No gallery images uploaded yet.
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
         </aside>
+        {activeTab === "images" ? (
+          <section className="rounded-[2rem] border border-black/10 bg-paper p-6 shadow-sm">
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-ink-500">
+                  Gallery
+                </p>
+                <h2 className="mt-2 font-display text-4xl uppercase text-ink-900">
+                  Photos
+                </h2>
+              </div>
+              <label className="inline-flex cursor-pointer items-center justify-center rounded-full bg-accent px-5 py-3 text-xs font-semibold uppercase tracking-[0.2em] text-white transition hover:shadow-glow">
+                {isUploadingImages ? "Uploading..." : "Upload JPEG"}
+                <input
+                  type="file"
+                  accept=".jpg,.jpeg,image/jpeg"
+                  multiple
+                  disabled={isUploadingImages}
+                  className="sr-only"
+                  onChange={(event) => {
+                    uploadGalleryImages(event.target.files);
+                    event.currentTarget.value = "";
+                  }}
+                />
+              </label>
+            </div>
+
+            {imageFeedback ? (
+              <p className="mt-6 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+                {imageFeedback}
+              </p>
+            ) : null}
+            {imageError ? (
+              <p className="mt-6 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+                {imageError}
+              </p>
+            ) : null}
+
+            <div className="mt-8 rounded-[1.5rem] border border-dashed border-black/10 px-5 py-4 text-sm text-ink-600">
+              Gallery photos are stored in SQLite and served to the public photo gallery from the database. Only .jpg and .jpeg files up to 1 MB are accepted.
+            </div>
+
+            {images.length > 0 ? (
+              <div className="mt-8 grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
+                {images.map((image) => (
+                  <article
+                    key={image.id}
+                    className="overflow-hidden rounded-[1.5rem] border border-black/10 bg-white"
+                  >
+                    <Image
+                      src={image.src}
+                      alt={image.title}
+                      width={900}
+                      height={700}
+                      unoptimized
+                      className="h-56 w-full object-cover"
+                    />
+                    <div className="space-y-4 p-5">
+                      <div>
+                        <h3 className="font-semibold text-ink-900">
+                          {image.title}
+                        </h3>
+                        <p className="mt-1 text-xs uppercase tracking-[0.16em] text-ink-500">
+                          {formatByteSize(image.byteSize)}
+                        </p>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => deleteGalleryImage(image.id)}
+                        disabled={deletingImageId === image.id}
+                        className="rounded-full border border-red-300 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-red-700 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        {deletingImageId === image.id ? "Deleting..." : "Delete"}
+                      </button>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            ) : (
+              <div className="mt-8 rounded-[1.5rem] border border-dashed border-black/10 px-6 py-16 text-center text-sm text-ink-500">
+                Upload JPEG images to populate the public photo gallery.
+              </div>
+            )}
+          </section>
+        ) : (
         <section className="rounded-[2rem] border border-black/10 bg-paper p-6 shadow-sm">
           <div className="flex flex-wrap items-center justify-between gap-4">
             <div>
@@ -673,6 +952,7 @@ export default function AdminDashboard({
             </div>
           )}
         </section>
+        )}
       </div>
     </div>
   );

--- a/lib/admin-gallery-images.ts
+++ b/lib/admin-gallery-images.ts
@@ -66,11 +66,7 @@ export function validateGalleryImageUpload(upload: GalleryImageUpload) {
   }
 }
 
-export async function saveGalleryImageUpload(
-  upload: GalleryImageUpload
-): Promise<GalleryImage> {
-  validateGalleryImageUpload(upload);
-
+function saveValidatedGalleryImageUpload(upload: GalleryImageUpload) {
   const id = randomUUID();
   const fileName = `${id}-${normalizeBaseName(upload.fileName)}.jpg`;
   const title = titleFromFileName(upload.fileName) || "Gallery image";
@@ -90,6 +86,20 @@ export async function saveGalleryImageUpload(
   }
 
   return savedImage;
+}
+
+export function saveGalleryImageUploads(
+  uploads: GalleryImageUpload[]
+): GalleryImage[] {
+  for (const upload of uploads) {
+    validateGalleryImageUpload(upload);
+  }
+
+  for (const upload of uploads) {
+    saveValidatedGalleryImageUpload(upload);
+  }
+
+  return getManagedGalleryImages();
 }
 
 export function removeGalleryImage(id: string) {

--- a/lib/admin-gallery-images.ts
+++ b/lib/admin-gallery-images.ts
@@ -1,0 +1,107 @@
+import path from "path";
+import { randomUUID } from "crypto";
+import type { GalleryImage } from "./types";
+import {
+  deleteGalleryImage,
+  getManagedGalleryImages,
+  insertGalleryImage
+} from "./shows-db";
+
+export type GalleryImageUpload = {
+  bytes: Uint8Array;
+  fileName: string;
+};
+
+export const MAX_IMAGE_UPLOAD_BYTES = 1024 * 1024;
+
+function normalizeBaseName(fileName: string) {
+  const parsed = path.parse(path.basename(fileName.trim()));
+  const baseName = parsed.name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return baseName || "gallery-image";
+}
+
+function titleFromFileName(fileName: string) {
+  return path
+    .parse(path.basename(fileName.trim()))
+    .name.replace(/[-_]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function isJpegFileName(fileName: string) {
+  const extension = path.extname(fileName).toLowerCase();
+  return extension === ".jpg" || extension === ".jpeg";
+}
+
+export function isJpegImage(bytes: Uint8Array) {
+  return (
+    bytes.length >= 4 &&
+    bytes[0] === 0xff &&
+    bytes[1] === 0xd8 &&
+    bytes[2] === 0xff &&
+    bytes[bytes.length - 2] === 0xff &&
+    bytes[bytes.length - 1] === 0xd9
+  );
+}
+
+export function validateGalleryImageUpload(upload: GalleryImageUpload) {
+  if (!isJpegFileName(upload.fileName)) {
+    throw new Error("Gallery images must use the .jpg or .jpeg extension.");
+  }
+
+  if (upload.bytes.length === 0) {
+    throw new Error("Gallery images cannot be empty.");
+  }
+
+  if (upload.bytes.length > MAX_IMAGE_UPLOAD_BYTES) {
+    throw new Error("Each gallery image must be 1 MB or smaller.");
+  }
+
+  if (!isJpegImage(upload.bytes)) {
+    throw new Error("Gallery images must be valid JPEG files.");
+  }
+}
+
+export async function saveGalleryImageUpload(
+  upload: GalleryImageUpload
+): Promise<GalleryImage> {
+  validateGalleryImageUpload(upload);
+
+  const id = randomUUID();
+  const fileName = `${id}-${normalizeBaseName(upload.fileName)}.jpg`;
+  const title = titleFromFileName(upload.fileName) || "Gallery image";
+
+  insertGalleryImage({
+    id,
+    fileName,
+    title,
+    bytes: upload.bytes,
+    createdAt: new Date().toISOString()
+  });
+
+  const savedImage = getManagedGalleryImages().find((image) => image.id === id);
+
+  if (!savedImage) {
+    throw new Error("Unable to save gallery image.");
+  }
+
+  return savedImage;
+}
+
+export function removeGalleryImage(id: string) {
+  const normalizedId = id.trim();
+
+  if (!normalizedId) {
+    throw new Error("Image ID is required.");
+  }
+
+  if (!deleteGalleryImage(normalizedId)) {
+    throw new Error("Gallery image was not found.");
+  }
+
+  return getManagedGalleryImages();
+}

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -1,12 +1,10 @@
 import fs from "fs";
 import path from "path";
 import type { Band, ShowsData, Member, MediaItem } from "./types";
-import { getShowsFromDatabase } from "./shows-db";
+import { getGalleryPhotosFromDatabase, getShowsFromDatabase } from "./shows-db";
 
 const dataDir = path.join(process.cwd(), "data");
-const showsImagesDir = path.join(process.cwd(), "public", "images", "shows");
 const allowedFiles = new Set(["band.json", "members.json", "media.json"]);
-const imageExtensions = new Set([".avif", ".gif", ".jpeg", ".jpg", ".png", ".webp"]);
 
 function readJson<T>(fileName: string): T {
   if (!allowedFiles.has(fileName)) {
@@ -33,46 +31,6 @@ export function getMedia(): MediaItem[] {
   return readJson<MediaItem[]>("media.json");
 }
 
-function shuffle<T>(items: T[]): T[] {
-  const randomized = [...items];
-  for (let i = randomized.length - 1; i > 0; i -= 1) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [randomized[i], randomized[j]] = [randomized[j], randomized[i]];
-  }
-  return randomized;
-}
-
-function toTitle(fileName: string): string {
-  const baseName = path.parse(fileName).name;
-  return baseName
-    .replace(/[-_]+/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
 export function getShowPhotos(): MediaItem[] {
-  if (!fs.existsSync(showsImagesDir)) {
-    return [];
-  }
-
-  const images = fs
-    .readdirSync(showsImagesDir, { withFileTypes: true })
-    .filter((entry) => entry.isFile())
-    .filter((entry) => imageExtensions.has(path.extname(entry.name).toLowerCase()))
-    .map((entry) => {
-      const fileName = entry.name;
-      const src = `/images/shows/${encodeURIComponent(fileName)}`;
-      const title = toTitle(fileName);
-
-      return {
-        id: `show-photo-${fileName.toLowerCase()}`,
-        type: "image" as const,
-        title,
-        src,
-        link: src,
-        alt: title
-      };
-    });
-
-  return shuffle(images);
+  return getGalleryPhotosFromDatabase();
 }

--- a/lib/shows-db.ts
+++ b/lib/shows-db.ts
@@ -1,7 +1,13 @@
 import fs from "fs";
 import path from "path";
 import Database from "better-sqlite3";
-import type { ManagedShow, ShowBucket, ShowsData } from "./types";
+import type {
+  GalleryImage,
+  ManagedShow,
+  MediaItem,
+  ShowBucket,
+  ShowsData
+} from "./types";
 import { getShowPosterSrc } from "./show-posters";
 
 type ShowRow = {
@@ -18,6 +24,19 @@ type ShowRow = {
   doors_open_time: string | null;
   cover_fee: string | null;
   poster_file_name: string | null;
+};
+
+type GalleryImageRow = {
+  id: string;
+  file_name: string;
+  title: string;
+  mime_type: "image/jpeg";
+  byte_size: number;
+  created_at: string;
+};
+
+type GalleryImageContentRow = GalleryImageRow & {
+  content: Buffer;
 };
 
 const dataDir = path.join(process.cwd(), "data");
@@ -53,9 +72,34 @@ function getDatabase() {
       poster_file_name TEXT
     );
   `);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS gallery_images (
+      id TEXT PRIMARY KEY,
+      file_name TEXT NOT NULL UNIQUE,
+      title TEXT NOT NULL,
+      mime_type TEXT NOT NULL CHECK(mime_type = 'image/jpeg'),
+      byte_size INTEGER NOT NULL,
+      content BLOB NOT NULL,
+      created_at TEXT NOT NULL
+    );
+  `);
   database = db;
 
   return database;
+}
+
+function mapGalleryImageRow(row: GalleryImageRow): GalleryImage {
+  const src = `/gallery-images/${encodeURIComponent(row.file_name)}`;
+
+  return {
+    id: row.id,
+    fileName: row.file_name,
+    title: row.title,
+    src,
+    mimeType: row.mime_type,
+    byteSize: row.byte_size,
+    createdAt: row.created_at
+  };
 }
 
 function mapShowRow(row: ShowRow): ManagedShow {
@@ -178,4 +222,115 @@ export function replaceShows(shows: ManagedShow[]) {
     db.exec("ROLLBACK;");
     throw error;
   }
+}
+
+export function getManagedGalleryImages(): GalleryImage[] {
+  const db = getDatabase();
+  const rows = db
+    .prepare(
+      `
+        SELECT
+          id,
+          file_name,
+          title,
+          mime_type,
+          byte_size,
+          created_at
+        FROM gallery_images
+        ORDER BY created_at DESC, file_name ASC;
+      `
+    )
+    .all() as GalleryImageRow[];
+
+  return rows.map(mapGalleryImageRow);
+}
+
+function shuffle<T>(items: T[]): T[] {
+  const randomized = [...items];
+  for (let i = randomized.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [randomized[i], randomized[j]] = [randomized[j], randomized[i]];
+  }
+  return randomized;
+}
+
+export function getGalleryPhotosFromDatabase(): MediaItem[] {
+  return shuffle(
+    getManagedGalleryImages().map((image) => ({
+      id: image.id,
+      type: "image" as const,
+      title: image.title,
+      src: image.src,
+      link: image.src,
+      alt: image.title
+    }))
+  );
+}
+
+export function insertGalleryImage({
+  id,
+  fileName,
+  title,
+  bytes,
+  createdAt
+}: {
+  id: string;
+  fileName: string;
+  title: string;
+  bytes: Uint8Array;
+  createdAt: string;
+}) {
+  const db = getDatabase();
+
+  db.prepare(
+    `
+      INSERT INTO gallery_images (
+        id,
+        file_name,
+        title,
+        mime_type,
+        byte_size,
+        content,
+        created_at
+      ) VALUES (?, ?, ?, 'image/jpeg', ?, ?, ?);
+    `
+  ).run(id, fileName, title, bytes.length, Buffer.from(bytes), createdAt);
+}
+
+export function deleteGalleryImage(id: string) {
+  const db = getDatabase();
+  const result = db
+    .prepare("DELETE FROM gallery_images WHERE id = ?;")
+    .run(id.trim());
+
+  return result.changes > 0;
+}
+
+export function readGalleryImage(fileName: string) {
+  const db = getDatabase();
+  const row = db
+    .prepare(
+      `
+        SELECT
+          id,
+          file_name,
+          title,
+          mime_type,
+          byte_size,
+          created_at,
+          content
+        FROM gallery_images
+        WHERE file_name = ?;
+      `
+    )
+    .get(path.basename(fileName.trim())) as GalleryImageContentRow | undefined;
+
+  if (!row) {
+    return null;
+  }
+
+  return {
+    image: mapGalleryImageRow(row),
+    content: row.content
+  };
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -61,3 +61,13 @@ export type MediaItem = {
   link: string;
   alt?: string;
 };
+
+export type GalleryImage = {
+  id: string;
+  fileName: string;
+  title: string;
+  src: string;
+  mimeType: "image/jpeg";
+  byteSize: number;
+  createdAt: string;
+};


### PR DESCRIPTION
- Add `Images` tab to `/admin`
- Support bulk JPEG uploads with 1 MB per-file limit
- Support deleting gallery images from admin
- Store gallery image bytes in SQLite
- Serve gallery images through `/gallery-images/[fileName]`
- Load `/video/photos` from the gallery image database instead of `public/images/shows`
- Update docs for the new gallery image workflow