### PR TITLE
move gallery image uploads from SQLite BLOBs to disk storage - Closes #62

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 ## Project Purpose
 - This repository powers the public website for the band **Sweetside**.
 - Primary goals: show upcoming/past shows, media gallery, streaming links, merch placeholder, and booking contact.
-- Band/member/video media content is file-driven, while shows and photo gallery images are stored in SQLite.
+- Band/member/video media content is file-driven, while shows and photo gallery metadata are stored in SQLite.
 
 ## Tech Stack
 - **Next.js 16** (App Router) + **React 18** + **TypeScript (strict)**.
@@ -55,7 +55,7 @@
 - Show data is loaded from SQLite through `lib/shows-db.ts`.
 - Upcoming show records may include optional `venue_url`, `tickets_url`, time, fee, address, and poster fields.
 - Public show lists are sorted by date descending within `upcoming` and `past`.
-- Show photos for `/video/photos` are loaded from the SQLite-backed admin gallery, not from JSON or `public/images/shows/`.
+- Show photos for `/video/photos` are loaded from the SQLite-backed admin gallery metadata, not from JSON or `public/images/shows/`.
 - Components/pages rely on these TypeScript types in `lib/types.ts`.
 
 ## Data Files: What They Drive
@@ -66,7 +66,7 @@
 - `data/media.json`:
   - video items for the `/video` gallery page.
 - `data/shows.sqlite`:
-  - local default SQLite database for shows and photo gallery images during non-Docker development.
+  - local default SQLite database for shows and photo gallery image metadata during non-Docker development.
   - upcoming rows may include `tickets_url` for the public Tickets button.
 - `storage/posters/`:
   - local default writable poster storage outside `public/`.
@@ -74,8 +74,12 @@
   - `/app/storage/shows.sqlite`
   - `/app/storage/posters/`
 - Photo gallery images:
-  - source of truth is the `gallery_images` table in SQLite.
+  - source of truth for metadata is the `gallery_images` table in SQLite.
+  - uploaded image files are stored in runtime storage.
+  - local default gallery image storage is `storage/gallery-images/`.
+  - Docker gallery image storage lives beside the database inside the mounted `/app/storage` volume.
   - public images are served through `/gallery-images/[fileName]`.
+  - public image responses use immutable cache headers because uploaded filenames are stable and UUID-prefixed.
   - admin uploads accept `.jpg` and `.jpeg` files only, 1 MB max each.
   - gallery records are shuffled during static generation.
   - use the admin Images sync button to revalidate the static gallery from SQLite.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ When Spotify is set to a supported Spotify URL (`artist`, `album`, `track`, `pla
 
 ## Images and media
 
-Photos on `/video/photos` are loaded from the SQLite-backed admin gallery and shuffled during static generation. Use `/admin` → `Images` to upload, delete, or sync gallery photos.
+Photos on `/video/photos` are loaded from the admin gallery metadata in SQLite and shuffled during static generation. Uploaded gallery image files live in runtime storage. Use `/admin` → `Images` to upload, delete, or sync gallery photos.
 
 Place other images in `public/images/` and reference them by absolute path in JSON, e.g.
 
@@ -110,6 +110,10 @@ Shows load through `lib/shows-db.ts`.
 - Local poster storage defaults to `storage/posters/`.
 - Docker poster storage lives beside the database inside the mounted `/app/storage` volume.
 - Posters are served through `/posters/:fileName`.
+- Uploaded gallery images are stored in runtime storage.
+- Local gallery image storage defaults to `storage/gallery-images/`.
+- Docker gallery image storage lives beside the database inside the mounted `/app/storage` volume.
+- Gallery images are served through `/gallery-images/:fileName` with immutable cache headers.
 - Upcoming shows may also store an optional `tickets_url` value in SQLite for the public Tickets button.
 
 ## Admin
@@ -135,4 +139,4 @@ Admin API protection:
 - login and sync endpoints use an in-memory process-wide rate limiter
 - logout clears the admin session cookie server-side and the client navigates directly to `/admin/login`
 - sync validates poster extension, PNG file signature, upload size limits, and show writes in the same request
-- gallery image uploads validate extension, JPEG file signature, and upload size before storing image bytes in SQLite
+- gallery image uploads validate extension, JPEG file signature, and upload size before storing files on disk and metadata in SQLite

--- a/app/api/admin/gallery-images/route.ts
+++ b/app/api/admin/gallery-images/route.ts
@@ -56,7 +56,7 @@ export async function POST(request: Request) {
       }))
     );
 
-    const images = saveGalleryImageUploads(uploads);
+    const images = await saveGalleryImageUploads(uploads);
 
     revalidatePath("/video/photos");
     revalidatePath("/admin");
@@ -93,7 +93,7 @@ export async function DELETE(request: Request) {
       throw new Error("Image ID is required.");
     }
 
-    const images = removeGalleryImage(payload.id);
+    const images = await removeGalleryImage(payload.id);
 
     revalidatePath("/video/photos");
     revalidatePath("/admin");

--- a/app/gallery-images/[fileName]/route.ts
+++ b/app/gallery-images/[fileName]/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from "next/server";
-import { readGalleryImage } from "@/lib/shows-db";
+import {
+  readGalleryImageFile,
+  sanitizeGalleryImageFileName
+} from "@/lib/gallery-image-files";
 
 export const runtime = "nodejs";
 
@@ -7,17 +10,22 @@ export async function GET(
   _request: Request,
   context: { params: Promise<{ fileName: string }> }
 ) {
-  const { fileName } = await context.params;
-  const galleryImage = readGalleryImage(fileName);
+  try {
+    const { fileName } = await context.params;
+    const normalizedFileName = sanitizeGalleryImageFileName(fileName);
+    const galleryImage = readGalleryImageFile(normalizedFileName);
 
-  if (!galleryImage) {
+    if (!galleryImage) {
+      return new NextResponse("Not found.", { status: 404 });
+    }
+
+    return new NextResponse(galleryImage, {
+      headers: {
+        "Content-Type": "image/jpeg",
+        "Cache-Control": "public, max-age=31536000, immutable"
+      }
+    });
+  } catch {
     return new NextResponse("Not found.", { status: 404 });
   }
-
-  return new NextResponse(new Uint8Array(galleryImage.content), {
-    headers: {
-      "Content-Type": galleryImage.image.mimeType,
-      "Cache-Control": "public, max-age=31536000, immutable"
-    }
-  });
 }

--- a/components/admin/AdminDashboard.tsx
+++ b/components/admin/AdminDashboard.tsx
@@ -625,7 +625,7 @@ export default function AdminDashboard({
             ) : null}
 
             <div className="mt-8 rounded-[1.5rem] border border-dashed border-black/10 px-5 py-4 text-sm text-ink-600">
-              Gallery photos are stored in SQLite and served to the public photo gallery from the database. Only .jpg and .jpeg files up to 1 MB are accepted.
+              Gallery photo metadata is stored in SQLite, while uploaded files live in runtime storage and are served with immutable cache headers. Only .jpg and .jpeg files up to 1 MB are accepted.
             </div>
 
             {images.length > 0 ? (
@@ -635,14 +635,20 @@ export default function AdminDashboard({
                     key={image.id}
                     className="overflow-hidden rounded-[1.5rem] border border-black/10 bg-white"
                   >
-                    <Image
-                      src={image.src}
-                      alt={image.title}
-                      width={900}
-                      height={700}
-                      unoptimized
-                      className="h-56 w-full object-cover"
-                    />
+                    {image.src ? (
+                      <Image
+                        src={image.src}
+                        alt={image.title}
+                        width={900}
+                        height={700}
+                        unoptimized
+                        className="h-56 w-full object-cover"
+                      />
+                    ) : (
+                      <div className="flex h-56 items-center justify-center bg-haze/60 px-6 text-center text-sm text-ink-500">
+                        Image file is missing from runtime storage.
+                      </div>
+                    )}
                     <div className="space-y-4 p-5">
                       <div>
                         <h3 className="font-semibold text-ink-900">

--- a/lib/admin-gallery-images.ts
+++ b/lib/admin-gallery-images.ts
@@ -2,7 +2,12 @@ import path from "path";
 import { randomUUID } from "crypto";
 import type { GalleryImage } from "./types";
 import {
+  deleteGalleryImageFile,
+  saveGalleryImageFile
+} from "./gallery-image-files";
+import {
   deleteGalleryImage,
+  getManagedGalleryImageById,
   getManagedGalleryImages,
   insertGalleryImage
 } from "./shows-db";
@@ -66,20 +71,27 @@ export function validateGalleryImageUpload(upload: GalleryImageUpload) {
   }
 }
 
-function saveValidatedGalleryImageUpload(upload: GalleryImageUpload) {
+async function saveValidatedGalleryImageUpload(upload: GalleryImageUpload) {
   const id = randomUUID();
   const fileName = `${id}-${normalizeBaseName(upload.fileName)}.jpg`;
   const title = titleFromFileName(upload.fileName) || "Gallery image";
 
-  insertGalleryImage({
-    id,
-    fileName,
-    title,
-    bytes: upload.bytes,
-    createdAt: new Date().toISOString()
-  });
+  await saveGalleryImageFile(fileName, upload.bytes);
 
-  const savedImage = getManagedGalleryImages().find((image) => image.id === id);
+  try {
+    insertGalleryImage({
+      id,
+      fileName,
+      title,
+      byteSize: upload.bytes.length,
+      createdAt: new Date().toISOString()
+    });
+  } catch (error) {
+    await deleteGalleryImageFile(fileName);
+    throw error;
+  }
+
+  const savedImage = getManagedGalleryImageById(id);
 
   if (!savedImage) {
     throw new Error("Unable to save gallery image.");
@@ -90,24 +102,34 @@ function saveValidatedGalleryImageUpload(upload: GalleryImageUpload) {
 
 export function saveGalleryImageUploads(
   uploads: GalleryImageUpload[]
-): GalleryImage[] {
+): Promise<GalleryImage[]> {
   for (const upload of uploads) {
     validateGalleryImageUpload(upload);
   }
 
-  for (const upload of uploads) {
-    saveValidatedGalleryImageUpload(upload);
-  }
+  return (async () => {
+    for (const upload of uploads) {
+      await saveValidatedGalleryImageUpload(upload);
+    }
 
-  return getManagedGalleryImages();
+    return getManagedGalleryImages();
+  })();
 }
 
-export function removeGalleryImage(id: string) {
+export async function removeGalleryImage(id: string) {
   const normalizedId = id.trim();
 
   if (!normalizedId) {
     throw new Error("Image ID is required.");
   }
+
+  const image = getManagedGalleryImageById(normalizedId);
+
+  if (!image) {
+    throw new Error("Gallery image was not found.");
+  }
+
+  await deleteGalleryImageFile(image.fileName);
 
   if (!deleteGalleryImage(normalizedId)) {
     throw new Error("Gallery image was not found.");

--- a/lib/gallery-image-files.ts
+++ b/lib/gallery-image-files.ts
@@ -1,0 +1,87 @@
+import fs from "fs";
+import path from "path";
+
+function getGalleryImagesDir() {
+  const configuredDatabasePath = process.env.SHOWS_DB_PATH?.trim();
+
+  if (configuredDatabasePath) {
+    const absoluteDatabasePath = path.resolve(
+      process.cwd(),
+      configuredDatabasePath
+    );
+    return path.join(path.dirname(absoluteDatabasePath), "gallery-images");
+  }
+
+  return path.join(process.cwd(), "storage", "gallery-images");
+}
+
+function ensureGalleryImagesDir() {
+  fs.mkdirSync(getGalleryImagesDir(), { recursive: true });
+}
+
+function normalizeGalleryImageFileName(fileName: string) {
+  return path.basename(fileName.trim());
+}
+
+function getGalleryImagePath(fileName: string) {
+  return path.join(
+    getGalleryImagesDir(),
+    normalizeGalleryImageFileName(fileName)
+  );
+}
+
+export function getGalleryImageSrc(fileName?: string): string | undefined {
+  if (!fileName) {
+    return undefined;
+  }
+
+  const normalizedFileName = normalizeGalleryImageFileName(fileName);
+  const filePath = getGalleryImagePath(normalizedFileName);
+
+  if (!fs.existsSync(filePath)) {
+    return undefined;
+  }
+
+  return `/gallery-images/${encodeURIComponent(normalizedFileName)}`;
+}
+
+export async function saveGalleryImageFile(
+  fileName: string,
+  bytes: Uint8Array
+) {
+  ensureGalleryImagesDir();
+  await fs.promises.writeFile(getGalleryImagePath(fileName), bytes);
+}
+
+export async function deleteGalleryImageFile(fileName?: string) {
+  if (!fileName) {
+    return;
+  }
+
+  const filePath = getGalleryImagePath(fileName);
+  if (fs.existsSync(filePath)) {
+    await fs.promises.unlink(filePath);
+  }
+}
+
+export function sanitizeGalleryImageFileName(fileName: string) {
+  const normalizedFileName = normalizeGalleryImageFileName(fileName);
+  const extension = path.extname(normalizedFileName).toLowerCase();
+
+  if (extension !== ".jpg" && extension !== ".jpeg") {
+    throw new Error("Gallery images must use the .jpg or .jpeg extension.");
+  }
+
+  return normalizedFileName;
+}
+
+export function readGalleryImageFile(fileName: string) {
+  const normalizedFileName = sanitizeGalleryImageFileName(fileName);
+  const filePath = getGalleryImagePath(normalizedFileName);
+
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+
+  return fs.readFileSync(filePath);
+}

--- a/lib/shows-db.ts
+++ b/lib/shows-db.ts
@@ -31,7 +31,6 @@ type GalleryImageRow = {
   id: string;
   file_name: string;
   title: string;
-  mime_type: "image/jpeg";
   byte_size: number;
   created_at: string;
 };
@@ -74,7 +73,6 @@ function getDatabase() {
       id TEXT PRIMARY KEY,
       file_name TEXT NOT NULL UNIQUE,
       title TEXT NOT NULL,
-      mime_type TEXT NOT NULL CHECK(mime_type = 'image/jpeg'),
       byte_size INTEGER NOT NULL,
       created_at TEXT NOT NULL
     );
@@ -90,7 +88,6 @@ function mapGalleryImageRow(row: GalleryImageRow): GalleryImage {
     fileName: row.file_name,
     title: row.title,
     src: getGalleryImageSrc(row.file_name),
-    mimeType: row.mime_type,
     byteSize: row.byte_size,
     createdAt: row.created_at
   };
@@ -227,7 +224,6 @@ export function getManagedGalleryImages(): GalleryImage[] {
           id,
           file_name,
           title,
-          mime_type,
           byte_size,
           created_at
         FROM gallery_images
@@ -248,7 +244,6 @@ export function getManagedGalleryImageById(id: string): GalleryImage | null {
           id,
           file_name,
           title,
-          mime_type,
           byte_size,
           created_at
         FROM gallery_images
@@ -308,10 +303,9 @@ export function insertGalleryImage({
         id,
         file_name,
         title,
-        mime_type,
         byte_size,
         created_at
-      ) VALUES (?, ?, ?, 'image/jpeg', ?, ?);
+      ) VALUES (?, ?, ?, ?, ?);
     `
   ).run(id, fileName, title, byteSize, createdAt);
 }

--- a/lib/shows-db.ts
+++ b/lib/shows-db.ts
@@ -8,6 +8,7 @@ import type {
   ShowBucket,
   ShowsData
 } from "./types";
+import { getGalleryImageSrc } from "./gallery-image-files";
 import { getShowPosterSrc } from "./show-posters";
 
 type ShowRow = {
@@ -33,10 +34,6 @@ type GalleryImageRow = {
   mime_type: "image/jpeg";
   byte_size: number;
   created_at: string;
-};
-
-type GalleryImageContentRow = GalleryImageRow & {
-  content: Buffer;
 };
 
 const dataDir = path.join(process.cwd(), "data");
@@ -79,7 +76,6 @@ function getDatabase() {
       title TEXT NOT NULL,
       mime_type TEXT NOT NULL CHECK(mime_type = 'image/jpeg'),
       byte_size INTEGER NOT NULL,
-      content BLOB NOT NULL,
       created_at TEXT NOT NULL
     );
   `);
@@ -89,13 +85,11 @@ function getDatabase() {
 }
 
 function mapGalleryImageRow(row: GalleryImageRow): GalleryImage {
-  const src = `/gallery-images/${encodeURIComponent(row.file_name)}`;
-
   return {
     id: row.id,
     fileName: row.file_name,
     title: row.title,
-    src,
+    src: getGalleryImageSrc(row.file_name),
     mimeType: row.mime_type,
     byteSize: row.byte_size,
     createdAt: row.created_at
@@ -245,6 +239,27 @@ export function getManagedGalleryImages(): GalleryImage[] {
   return rows.map(mapGalleryImageRow);
 }
 
+export function getManagedGalleryImageById(id: string): GalleryImage | null {
+  const db = getDatabase();
+  const row = db
+    .prepare(
+      `
+        SELECT
+          id,
+          file_name,
+          title,
+          mime_type,
+          byte_size,
+          created_at
+        FROM gallery_images
+        WHERE id = ?;
+      `
+    )
+    .get(id.trim()) as GalleryImageRow | undefined;
+
+  return row ? mapGalleryImageRow(row) : null;
+}
+
 function shuffle<T>(items: T[]): T[] {
   const randomized = [...items];
   for (let i = randomized.length - 1; i > 0; i -= 1) {
@@ -256,14 +271,19 @@ function shuffle<T>(items: T[]): T[] {
 
 export function getGalleryPhotosFromDatabase(): MediaItem[] {
   return shuffle(
-    getManagedGalleryImages().map((image) => ({
-      id: image.id,
-      type: "image" as const,
-      title: image.title,
-      src: image.src,
-      link: image.src,
-      alt: image.title
-    }))
+    getManagedGalleryImages()
+      .filter(
+        (image): image is GalleryImage & { src: string } =>
+          typeof image.src === "string"
+      )
+      .map((image) => ({
+        id: image.id,
+        type: "image" as const,
+        title: image.title,
+        src: image.src,
+        link: image.src,
+        alt: image.title
+      }))
   );
 }
 
@@ -271,13 +291,13 @@ export function insertGalleryImage({
   id,
   fileName,
   title,
-  bytes,
+  byteSize,
   createdAt
 }: {
   id: string;
   fileName: string;
   title: string;
-  bytes: Uint8Array;
+  byteSize: number;
   createdAt: string;
 }) {
   const db = getDatabase();
@@ -290,11 +310,10 @@ export function insertGalleryImage({
         title,
         mime_type,
         byte_size,
-        content,
         created_at
-      ) VALUES (?, ?, ?, 'image/jpeg', ?, ?, ?);
+      ) VALUES (?, ?, ?, 'image/jpeg', ?, ?);
     `
-  ).run(id, fileName, title, bytes.length, Buffer.from(bytes), createdAt);
+  ).run(id, fileName, title, byteSize, createdAt);
 }
 
 export function deleteGalleryImage(id: string) {
@@ -304,33 +323,4 @@ export function deleteGalleryImage(id: string) {
     .run(id.trim());
 
   return result.changes > 0;
-}
-
-export function readGalleryImage(fileName: string) {
-  const db = getDatabase();
-  const row = db
-    .prepare(
-      `
-        SELECT
-          id,
-          file_name,
-          title,
-          mime_type,
-          byte_size,
-          created_at,
-          content
-        FROM gallery_images
-        WHERE file_name = ?;
-      `
-    )
-    .get(path.basename(fileName.trim())) as GalleryImageContentRow | undefined;
-
-  if (!row) {
-    return null;
-  }
-
-  return {
-    image: mapGalleryImageRow(row),
-    content: row.content
-  };
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -66,7 +66,7 @@ export type GalleryImage = {
   id: string;
   fileName: string;
   title: string;
-  src: string;
+  src?: string;
   mimeType: "image/jpeg";
   byteSize: number;
   createdAt: string;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -67,7 +67,6 @@ export type GalleryImage = {
   fileName: string;
   title: string;
   src?: string;
-  mimeType: "image/jpeg";
   byteSize: number;
   createdAt: string;
 };


### PR DESCRIPTION
This PR changes gallery image storage so uploaded JPEG files are written to runtime storage instead of being stored and served from SQLite BLOBs.

## Changes

- Store gallery image files in `storage/gallery-images/` locally, or beside `SHOWS_DB_PATH` in Docker/runtime storage
- Keep only gallery metadata and file names in SQLite
- Serve `/gallery-images/[fileName]` from disk with immutable cache headers
- Remove redundant gallery MIME metadata from the SQLite schema and TypeScript type
- Update admin copy and docs to describe the new storage model
- Skip public gallery photos whose referenced file is missing, while showing a missing-file placeholder in admin