### PR TITLE
use Random Hex IDs for Shows

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Shows load through `lib/shows-db.ts`.
 - Local default database path is `data/shows.sqlite`.
 - Docker stores the database in a named volume mounted at `/app/storage/shows.sqlite`.
 - Public pages still read through `lib/content.ts`, so the UI contracts stay the same.
+- Show IDs use the immutable `ss-xxxxxxxx` format, with eight random lowercase hex characters. Existing databases migrate automatically on first startup.
 - Uploaded posters are stored in runtime storage.
 - Local poster storage defaults to `storage/posters/`.
 - Docker poster storage lives beside the database inside the mounted `/app/storage` volume.

--- a/components/admin/AdminDashboard.tsx
+++ b/components/admin/AdminDashboard.tsx
@@ -9,7 +9,7 @@ import type {
   ManagedShow,
   ShowBucket
 } from "@/lib/types";
-import { deriveShowId } from "@/lib/show-id";
+import { generateShowId } from "@/lib/show-id";
 
 type EditableShow = ManagedShow & {
   clientKey: string;
@@ -44,7 +44,6 @@ function formatByteSize(byteSize: number) {
 function toEditableShow(show: ManagedShow): EditableShow {
   return {
     ...show,
-    id: deriveShowId(show.date),
     clientKey: createClientKey(),
     originalId: show.id,
     pendingPosterFile: null,
@@ -67,14 +66,12 @@ function groupCount(shows: EditableShow[], bucket: ShowBucket) {
 }
 
 function createBlankShow(bucket: ShowBucket): EditableShow {
-  const id = deriveShowId("");
-
   return {
     clientKey: createClientKey(),
     originalId: null,
     bucket,
     sortOrder: 0,
-    id,
+    id: generateShowId(),
     date: "",
     city: "",
     venue: "",
@@ -208,18 +205,10 @@ export default function AdminDashboard({
     setShows((currentShows) =>
       currentShows.map((show) =>
         show.clientKey === clientKey
-          ? (() => {
-              const updatedShow = {
-                ...show,
-                [field]: value
-              };
-
-              if (field === "date") {
-                updatedShow.id = deriveShowId(value);
-              }
-
-              return updatedShow;
-            })()
+          ? {
+              ...show,
+              [field]: value
+            }
           : show
       )
     );
@@ -347,6 +336,7 @@ export default function AdminDashboard({
       const payload = shows.map((show) => ({
         clientKey: show.clientKey,
         originalId: show.originalId,
+        id: show.id,
         bucket: show.bucket,
         date: show.date,
         city: show.city,
@@ -368,7 +358,7 @@ export default function AdminDashboard({
       }
 
       try {
-        const currentSelectedId = selectedShow ? deriveShowId(selectedShow.date) : null;
+        const currentSelectedId = selectedShow?.id ?? null;
         const response = await fetch("/api/admin/sync", {
           method: "POST",
           body: formData

--- a/lib/admin-shows.ts
+++ b/lib/admin-shows.ts
@@ -5,11 +5,12 @@ import {
   sanitizePosterFileName
 } from "./show-posters";
 import { getManagedShows, replaceShows } from "./shows-db";
-import { deriveShowId, isIsoShowDate } from "./show-id";
+import { isIsoShowDate, isShowId } from "./show-id";
 
 export type ShowSyncInput = {
   clientKey: string;
   originalId: string | null;
+  id: string;
   bucket: ShowBucket;
   date: string;
   city: string;
@@ -68,6 +69,13 @@ function normalizeOptionalAbsoluteUrl(value: string | undefined, field: string) 
 }
 
 function normalizeShowInput(input: ShowSyncInput, sortOrder: number): ManagedShow {
+  const id = normalizeRequiredValue(input.id, "Show ID");
+  if (!isShowId(id)) {
+    throw new Error(
+      "Show ID must use the format ss- followed by 8 lowercase hex characters."
+    );
+  }
+
   const date = normalizeRequiredValue(input.date, "Date");
   if (!isIsoShowDate(date)) {
     throw new Error("Date must use YYYY-MM-DD.");
@@ -77,7 +85,6 @@ function normalizeShowInput(input: ShowSyncInput, sortOrder: number): ManagedSho
     throw new Error("Show bucket must be upcoming or past.");
   }
 
-  const id = deriveShowId(date);
   const detailFields =
     input.bucket === "upcoming"
       ? {

--- a/lib/show-id.ts
+++ b/lib/show-id.ts
@@ -1,9 +1,21 @@
 const isoDatePattern = /^\d{4}-\d{2}-\d{2}$/;
+const showIdPattern = /^ss-[0-9a-f]{8}$/;
 
 export function isIsoShowDate(value: string) {
   return isoDatePattern.test(value);
 }
 
-export function deriveShowId(date: string) {
-  return isIsoShowDate(date) ? `ss-${date}` : "";
+export function isShowId(value: string) {
+  return showIdPattern.test(value);
+}
+
+export function generateShowId() {
+  const bytes = new Uint8Array(4);
+  globalThis.crypto.getRandomValues(bytes);
+
+  const randomHex = Array.from(bytes, (byte) =>
+    byte.toString(16).padStart(2, "0")
+  ).join("");
+
+  return `ss-${randomHex}`;
 }

--- a/lib/shows-db.ts
+++ b/lib/shows-db.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "crypto";
 import fs from "fs";
 import path from "path";
 import Database from "better-sqlite3";
@@ -55,6 +56,138 @@ const databasePath = process.env.SHOWS_DB_PATH?.trim()
 
 let database: Database.Database | null = null;
 
+const randomShowIdMigration = "shows-random-id-v1";
+
+function createShowsTableSql(
+  tableName: "shows" | "shows_random_id_migration"
+) {
+  return `
+  CREATE TABLE IF NOT EXISTS ${tableName} (
+    id TEXT PRIMARY KEY CHECK (
+      length(id) = 11
+      AND substr(id, 1, 3) = 'ss-'
+      AND substr(id, 4) NOT GLOB '*[^0-9a-f]*'
+    ),
+    bucket TEXT NOT NULL CHECK(bucket IN ('upcoming', 'past')),
+    sort_order INTEGER NOT NULL,
+    date TEXT NOT NULL,
+    city TEXT NOT NULL,
+    venue TEXT NOT NULL,
+    venue_url TEXT,
+    tickets_url TEXT,
+    venue_address TEXT,
+    show_time TEXT,
+    doors_open_time TEXT,
+    cover_fee TEXT,
+    poster_file_name TEXT
+  );
+`;
+}
+
+function generateUniqueShowId(assignedIds: Set<string>) {
+  let id: string;
+
+  do {
+    id = `ss-${randomBytes(4).toString("hex")}`;
+  } while (assignedIds.has(id));
+
+  assignedIds.add(id);
+  return id;
+}
+
+function migrateShowIds(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      name TEXT PRIMARY KEY,
+      applied_at TEXT NOT NULL
+    );
+  `);
+
+  db.exec("BEGIN IMMEDIATE;");
+
+  try {
+    const migrationApplied = db
+      .prepare("SELECT 1 FROM schema_migrations WHERE name = ?;")
+      .get(randomShowIdMigration);
+
+    if (migrationApplied) {
+      db.exec("COMMIT;");
+      return;
+    }
+
+    const rows = db
+      .prepare(
+        `
+          SELECT
+            bucket,
+            sort_order,
+            date,
+            city,
+            venue,
+            venue_url,
+            tickets_url,
+            venue_address,
+            show_time,
+            doors_open_time,
+            cover_fee,
+            poster_file_name
+          FROM shows;
+        `
+      )
+      .all() as Omit<ShowRow, "id">[];
+    const assignedIds = new Set<string>();
+
+    db.exec("DROP TABLE IF EXISTS shows_random_id_migration;");
+    db.exec(createShowsTableSql("shows_random_id_migration"));
+
+    const insert = db.prepare(`
+      INSERT INTO shows_random_id_migration (
+        id,
+        bucket,
+        sort_order,
+        date,
+        city,
+        venue,
+        venue_url,
+        tickets_url,
+        venue_address,
+        show_time,
+        doors_open_time,
+        cover_fee,
+        poster_file_name
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+    `);
+
+    for (const row of rows) {
+      insert.run(
+        generateUniqueShowId(assignedIds),
+        row.bucket,
+        row.sort_order,
+        row.date,
+        row.city,
+        row.venue,
+        row.venue_url,
+        row.tickets_url,
+        row.venue_address,
+        row.show_time,
+        row.doors_open_time,
+        row.cover_fee,
+        row.poster_file_name
+      );
+    }
+
+    db.exec("DROP TABLE shows;");
+    db.exec("ALTER TABLE shows_random_id_migration RENAME TO shows;");
+    db.prepare(
+      "INSERT INTO schema_migrations (name, applied_at) VALUES (?, ?);"
+    ).run(randomShowIdMigration, new Date().toISOString());
+    db.exec("COMMIT;");
+  } catch (error) {
+    db.exec("ROLLBACK;");
+    throw error;
+  }
+}
+
 function getDatabase() {
   if (database) {
     return database;
@@ -64,23 +197,8 @@ function getDatabase() {
   const db = new Database(databasePath);
   db.exec("PRAGMA journal_mode = WAL;");
   db.exec("PRAGMA synchronous = NORMAL;");
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS shows (
-      id TEXT PRIMARY KEY,
-      bucket TEXT NOT NULL CHECK(bucket IN ('upcoming', 'past')),
-      sort_order INTEGER NOT NULL,
-      date TEXT NOT NULL,
-      city TEXT NOT NULL,
-      venue TEXT NOT NULL,
-      venue_url TEXT,
-      tickets_url TEXT,
-      venue_address TEXT,
-      show_time TEXT,
-      doors_open_time TEXT,
-      cover_fee TEXT,
-      poster_file_name TEXT
-    );
-  `);
+  db.exec(createShowsTableSql("shows"));
+  migrateShowIds(db);
   db.exec(`
     CREATE TABLE IF NOT EXISTS gallery_images (
       id TEXT PRIMARY KEY,


### PR DESCRIPTION
- Updates show IDs from date-based values to immutable `ss-xxxxxxxx` random hex IDs, allowing multiple shows on the same date.
- Includes a transactional SQLite migration for existing shows, schema-level ID validation, and updated admin creation and sync logic.