### PR TITLE
add optimized WebP previews for gallery photos

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ Shows load through `lib/shows-db.ts`.
 - Uploaded gallery images are stored in runtime storage.
 - Local gallery image storage defaults to `storage/gallery-images/`.
 - Docker gallery image storage lives beside the database inside the mounted `/app/storage` volume.
-- Gallery images are served through `/gallery-images/:fileName` with immutable cache headers.
+- Original gallery JPEGs and generated WebP previews are served through `/gallery-images/:fileName` with immutable cache headers.
+- Uploads generate a WebP preview up to 1,200 px wide at 80% quality; both files live in the same gallery image storage directory and Docker volume.
 - Uploaded video thumbnails are stored in runtime storage.
 - Local video thumbnail storage defaults to `storage/video-thumbnails/`.
 - Docker video thumbnail storage lives beside the database inside the mounted `/app/storage` volume.
@@ -135,4 +136,5 @@ Admin API protection:
 - logout clears the admin session cookie server-side and the client navigates directly to `/admin/login`
 - sync validates poster extension, PNG file signature, upload size limits, and show writes in the same request
 - gallery image uploads validate extension, JPEG file signature, and upload size before storing files on disk and metadata in SQLite
+- opening the admin dashboard or using Images → Save changes idempotently backfills missing WebP previews for existing photos
 - video sync validates YouTube links, thumbnail extension, image file signature, and upload size before storing files on disk and metadata in SQLite

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,5 +1,6 @@
 import AdminDashboard from "@/components/admin/AdminDashboard";
 import { requireAdminAuthentication } from "@/lib/admin-auth";
+import { backfillGalleryImagePreviews } from "@/lib/admin-gallery-images";
 import {
   getManagedGalleryImages,
   getManagedGalleryVideos,
@@ -10,6 +11,7 @@ export const dynamic = "force-dynamic";
 
 export default async function AdminPage() {
   await requireAdminAuthentication();
+  await backfillGalleryImagePreviews();
   const shows = getManagedShows();
   const images = getManagedGalleryImages();
   const videos = getManagedGalleryVideos();

--- a/app/api/admin/gallery-images/route.ts
+++ b/app/api/admin/gallery-images/route.ts
@@ -2,6 +2,7 @@ import { revalidatePath } from "next/cache";
 import { NextResponse } from "next/server";
 import { ADMIN_COOKIE_NAME, verifyAdminSessionToken } from "@/lib/admin-auth";
 import {
+  backfillGalleryImagePreviews,
   removeGalleryImage,
   saveGalleryImageUploads
 } from "@/lib/admin-gallery-images";
@@ -123,11 +124,29 @@ export async function PUT(request: Request) {
     return unauthorized(rateLimit);
   }
 
-  revalidatePath("/video/photos");
-  revalidatePath("/admin");
+  try {
+    const backfill = await backfillGalleryImagePreviews();
 
-  return applyRateLimitHeaders(
-    NextResponse.json({ images: getManagedGalleryImages() }),
-    rateLimit.result
-  );
+    revalidatePath("/video/photos");
+    revalidatePath("/admin");
+
+    return applyRateLimitHeaders(
+      NextResponse.json({
+        images: getManagedGalleryImages(),
+        generatedPreviewCount: backfill.generatedCount,
+        failedPreviewCount: backfill.failedCount
+      }),
+      rateLimit.result
+    );
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "Unable to process gallery image previews.";
+
+    return applyRateLimitHeaders(
+      NextResponse.json({ error: message }, { status: 400 }),
+      rateLimit.result
+    );
+  }
 }

--- a/app/gallery-images/[fileName]/route.ts
+++ b/app/gallery-images/[fileName]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import {
+  getGalleryImageContentType,
   readGalleryImageFile,
   sanitizeGalleryImageFileName
 } from "@/lib/gallery-image-files";
@@ -21,7 +22,7 @@ export async function GET(
 
     return new NextResponse(galleryImage, {
       headers: {
-        "Content-Type": "image/jpeg",
+        "Content-Type": getGalleryImageContentType(normalizedFileName),
         "Cache-Control": "public, max-age=31536000, immutable"
       }
     });

--- a/components/PhotoMasonryGrid.tsx
+++ b/components/PhotoMasonryGrid.tsx
@@ -51,7 +51,7 @@ export default function PhotoMasonryGrid({ items }: { items: MediaItem[] }) {
   }, [activeItem]);
 
   useEffect(() => {
-    if (!activeItem?.src) {
+    if (!activeItem?.link) {
       return;
     }
 
@@ -75,12 +75,12 @@ export default function PhotoMasonryGrid({ items }: { items: MediaItem[] }) {
       setActiveImageSize(null);
     };
 
-    image.src = activeItem.src;
+    image.src = activeItem.link;
 
     return () => {
       isMounted = false;
     };
-  }, [activeItem?.src]);
+  }, [activeItem?.link]);
 
   const handleLightboxContentClick = (event: MouseEvent<HTMLDivElement>) => {
     if (!activeImageSize || activeImageSize.width === 0 || activeImageSize.height === 0) {
@@ -169,7 +169,7 @@ export default function PhotoMasonryGrid({ items }: { items: MediaItem[] }) {
             onClick={handleLightboxContentClick}
           >
             <Image
-              src={activeItem.src}
+              src={activeItem.link}
               alt={activeItem.alt ?? activeItem.title}
               fill
               sizes="95vw"

--- a/components/admin/AdminDashboard.tsx
+++ b/components/admin/AdminDashboard.tsx
@@ -676,6 +676,8 @@ export default function AdminDashboard({
         const result = (await response.json()) as {
           error?: string;
           images?: GalleryImage[];
+          generatedPreviewCount?: number;
+          failedPreviewCount?: number;
         };
 
         if (!response.ok || !result.images) {
@@ -684,7 +686,15 @@ export default function AdminDashboard({
         }
 
         setImages(result.images);
-        setImageFeedback("Photo changes saved successfully.");
+        const generatedCount = result.generatedPreviewCount ?? 0;
+        const failedCount = result.failedPreviewCount ?? 0;
+        setImageFeedback(
+          failedCount > 0
+            ? `Saved changes and generated ${generatedCount} previews; ${failedCount} photos could not be processed.`
+            : generatedCount > 0
+              ? `Saved changes and generated ${generatedCount} photo previews.`
+              : "Photo changes saved successfully."
+        );
         startTransition(() => {
           router.refresh();
         });
@@ -867,9 +877,9 @@ export default function AdminDashboard({
                     key={image.id}
                     className="group overflow-hidden rounded-2xl border border-black/10 bg-white transition hover:-translate-y-0.5 hover:shadow-lg"
                   >
-                    {image.src ? (
+                    {image.previewSrc || image.src ? (
                       <Image
-                        src={image.src}
+                        src={image.previewSrc ?? image.src!}
                         alt={image.title}
                         width={900}
                         height={700}
@@ -887,7 +897,9 @@ export default function AdminDashboard({
                           {image.title}
                         </h3>
                         <p className="mt-1 text-[11px] uppercase tracking-[0.14em] text-ink-500">
-                          {formatByteSize(image.byteSize)}
+                          {image.previewByteSize
+                            ? `${formatByteSize(image.previewByteSize)} preview · ${formatByteSize(image.byteSize)} original`
+                            : `${formatByteSize(image.byteSize)} original`}
                         </p>
                       </div>
                       <button

--- a/lib/admin-gallery-images.ts
+++ b/lib/admin-gallery-images.ts
@@ -1,15 +1,18 @@
 import path from "path";
 import { randomUUID } from "crypto";
+import sharp from "sharp";
 import type { GalleryImage } from "./types";
 import {
   deleteGalleryImageFile,
+  readGalleryImageFile,
   saveGalleryImageFile
 } from "./gallery-image-files";
 import {
   deleteGalleryImage,
   getManagedGalleryImageById,
   getManagedGalleryImages,
-  insertGalleryImage
+  insertGalleryImage,
+  updateGalleryImagePreview
 } from "./shows-db";
 
 export type GalleryImageUpload = {
@@ -18,6 +21,8 @@ export type GalleryImageUpload = {
 };
 
 export const MAX_IMAGE_UPLOAD_BYTES = 1024 * 1024;
+const PREVIEW_WIDTH = 1200;
+const PREVIEW_QUALITY = 80;
 
 function normalizeBaseName(fileName: string) {
   const parsed = path.parse(path.basename(fileName.trim()));
@@ -71,23 +76,47 @@ export function validateGalleryImageUpload(upload: GalleryImageUpload) {
   }
 }
 
+function getPreviewFileName(fileName: string) {
+  const parsed = path.parse(fileName);
+  return `${parsed.name}-preview.webp`;
+}
+
+async function createGalleryImagePreview(bytes: Uint8Array) {
+  return sharp(bytes, { failOn: "error" })
+    .rotate()
+    .resize({
+      width: PREVIEW_WIDTH,
+      withoutEnlargement: true
+    })
+    .webp({ quality: PREVIEW_QUALITY })
+    .toBuffer();
+}
+
 async function saveValidatedGalleryImageUpload(upload: GalleryImageUpload) {
   const id = randomUUID();
   const fileName = `${id}-${normalizeBaseName(upload.fileName)}.jpg`;
+  const previewFileName = getPreviewFileName(fileName);
   const title = titleFromFileName(upload.fileName) || "Gallery image";
+  const previewBytes = await createGalleryImagePreview(upload.bytes);
 
   await saveGalleryImageFile(fileName, upload.bytes);
 
   try {
+    await saveGalleryImageFile(previewFileName, previewBytes);
     insertGalleryImage({
       id,
       fileName,
       title,
       byteSize: upload.bytes.length,
+      previewFileName,
+      previewByteSize: previewBytes.length,
       createdAt: new Date().toISOString()
     });
   } catch (error) {
-    await deleteGalleryImageFile(fileName);
+    await Promise.all([
+      deleteGalleryImageFile(fileName),
+      deleteGalleryImageFile(previewFileName)
+    ]);
     throw error;
   }
 
@@ -98,6 +127,50 @@ async function saveValidatedGalleryImageUpload(upload: GalleryImageUpload) {
   }
 
   return savedImage;
+}
+
+export async function backfillGalleryImagePreviews() {
+  let generatedCount = 0;
+  let failedCount = 0;
+
+  for (const image of getManagedGalleryImages()) {
+    if (image.previewSrc) {
+      continue;
+    }
+
+    const originalBytes = readGalleryImageFile(image.fileName);
+    if (!originalBytes) {
+      failedCount += 1;
+      continue;
+    }
+
+    const previewFileName =
+      image.previewFileName ?? getPreviewFileName(image.fileName);
+
+    try {
+      const previewBytes = await createGalleryImagePreview(originalBytes);
+      await saveGalleryImageFile(previewFileName, previewBytes);
+
+      if (
+        !updateGalleryImagePreview(
+          image.id,
+          previewFileName,
+          previewBytes.length
+        )
+      ) {
+        await deleteGalleryImageFile(previewFileName);
+        failedCount += 1;
+        continue;
+      }
+
+      generatedCount += 1;
+    } catch {
+      await deleteGalleryImageFile(previewFileName);
+      failedCount += 1;
+    }
+  }
+
+  return { generatedCount, failedCount };
 }
 
 export function saveGalleryImageUploads(
@@ -129,7 +202,10 @@ export async function removeGalleryImage(id: string) {
     throw new Error("Gallery image was not found.");
   }
 
-  await deleteGalleryImageFile(image.fileName);
+  await Promise.all([
+    deleteGalleryImageFile(image.fileName),
+    deleteGalleryImageFile(image.previewFileName)
+  ]);
 
   if (!deleteGalleryImage(normalizedId)) {
     throw new Error("Gallery image was not found.");

--- a/lib/gallery-image-files.ts
+++ b/lib/gallery-image-files.ts
@@ -68,11 +68,21 @@ export function sanitizeGalleryImageFileName(fileName: string) {
   const normalizedFileName = normalizeGalleryImageFileName(fileName);
   const extension = path.extname(normalizedFileName).toLowerCase();
 
-  if (extension !== ".jpg" && extension !== ".jpeg") {
-    throw new Error("Gallery images must use the .jpg or .jpeg extension.");
+  if (
+    extension !== ".jpg" &&
+    extension !== ".jpeg" &&
+    extension !== ".webp"
+  ) {
+    throw new Error("Unsupported gallery image extension.");
   }
 
   return normalizedFileName;
+}
+
+export function getGalleryImageContentType(fileName: string) {
+  return path.extname(fileName).toLowerCase() === ".webp"
+    ? "image/webp"
+    : "image/jpeg";
 }
 
 export function readGalleryImageFile(fileName: string) {

--- a/lib/gallery-image-files.ts
+++ b/lib/gallery-image-files.ts
@@ -6,17 +6,26 @@ function getGalleryImagesDir() {
 
   if (configuredDatabasePath) {
     const absoluteDatabasePath = path.resolve(
-      process.cwd(),
+      /* turbopackIgnore: true */ process.cwd(),
       configuredDatabasePath
     );
-    return path.join(path.dirname(absoluteDatabasePath), "gallery-images");
+    return path.join(
+      /* turbopackIgnore: true */ path.dirname(absoluteDatabasePath),
+      "gallery-images"
+    );
   }
 
-  return path.join(process.cwd(), "storage", "gallery-images");
+  return path.join(
+    /* turbopackIgnore: true */ process.cwd(),
+    "storage",
+    "gallery-images"
+  );
 }
 
 function ensureGalleryImagesDir() {
-  fs.mkdirSync(getGalleryImagesDir(), { recursive: true });
+  fs.mkdirSync(/* turbopackIgnore: true */ getGalleryImagesDir(), {
+    recursive: true
+  });
 }
 
 function normalizeGalleryImageFileName(fileName: string) {
@@ -25,7 +34,7 @@ function normalizeGalleryImageFileName(fileName: string) {
 
 function getGalleryImagePath(fileName: string) {
   return path.join(
-    getGalleryImagesDir(),
+    /* turbopackIgnore: true */ getGalleryImagesDir(),
     normalizeGalleryImageFileName(fileName)
   );
 }
@@ -38,7 +47,7 @@ export function getGalleryImageSrc(fileName?: string): string | undefined {
   const normalizedFileName = normalizeGalleryImageFileName(fileName);
   const filePath = getGalleryImagePath(normalizedFileName);
 
-  if (!fs.existsSync(filePath)) {
+  if (!fs.existsSync(/* turbopackIgnore: true */ filePath)) {
     return undefined;
   }
 
@@ -50,7 +59,10 @@ export async function saveGalleryImageFile(
   bytes: Uint8Array
 ) {
   ensureGalleryImagesDir();
-  await fs.promises.writeFile(getGalleryImagePath(fileName), bytes);
+  await fs.promises.writeFile(
+    /* turbopackIgnore: true */ getGalleryImagePath(fileName),
+    bytes
+  );
 }
 
 export async function deleteGalleryImageFile(fileName?: string) {
@@ -59,8 +71,8 @@ export async function deleteGalleryImageFile(fileName?: string) {
   }
 
   const filePath = getGalleryImagePath(fileName);
-  if (fs.existsSync(filePath)) {
-    await fs.promises.unlink(filePath);
+  if (fs.existsSync(/* turbopackIgnore: true */ filePath)) {
+    await fs.promises.unlink(/* turbopackIgnore: true */ filePath);
   }
 }
 
@@ -89,9 +101,9 @@ export function readGalleryImageFile(fileName: string) {
   const normalizedFileName = sanitizeGalleryImageFileName(fileName);
   const filePath = getGalleryImagePath(normalizedFileName);
 
-  if (!fs.existsSync(filePath)) {
+  if (!fs.existsSync(/* turbopackIgnore: true */ filePath)) {
     return null;
   }
 
-  return fs.readFileSync(filePath);
+  return fs.readFileSync(/* turbopackIgnore: true */ filePath);
 }

--- a/lib/show-posters.ts
+++ b/lib/show-posters.ts
@@ -6,17 +6,26 @@ function getShowPostersDir() {
 
   if (configuredDatabasePath) {
     const absoluteDatabasePath = path.resolve(
-      process.cwd(),
+      /* turbopackIgnore: true */ process.cwd(),
       configuredDatabasePath
     );
-    return path.join(path.dirname(absoluteDatabasePath), "posters");
+    return path.join(
+      /* turbopackIgnore: true */ path.dirname(absoluteDatabasePath),
+      "posters"
+    );
   }
 
-  return path.join(process.cwd(), "storage", "posters");
+  return path.join(
+    /* turbopackIgnore: true */ process.cwd(),
+    "storage",
+    "posters"
+  );
 }
 
 function ensurePosterDir() {
-  fs.mkdirSync(getShowPostersDir(), { recursive: true });
+  fs.mkdirSync(/* turbopackIgnore: true */ getShowPostersDir(), {
+    recursive: true
+  });
 }
 
 function normalizePosterFileName(fileName: string) {
@@ -24,7 +33,10 @@ function normalizePosterFileName(fileName: string) {
 }
 
 function getPosterPath(fileName: string) {
-  return path.join(getShowPostersDir(), normalizePosterFileName(fileName));
+  return path.join(
+    /* turbopackIgnore: true */ getShowPostersDir(),
+    normalizePosterFileName(fileName)
+  );
 }
 
 export function getShowPosterSrc(fileName?: string): string | undefined {
@@ -35,7 +47,7 @@ export function getShowPosterSrc(fileName?: string): string | undefined {
   const normalizedFileName = normalizePosterFileName(fileName);
   const filePath = getPosterPath(normalizedFileName);
 
-  if (!fs.existsSync(filePath)) {
+  if (!fs.existsSync(/* turbopackIgnore: true */ filePath)) {
     return undefined;
   }
 
@@ -44,7 +56,10 @@ export function getShowPosterSrc(fileName?: string): string | undefined {
 
 export async function saveShowPoster(fileName: string, bytes: Uint8Array) {
   ensurePosterDir();
-  await fs.promises.writeFile(getPosterPath(fileName), bytes);
+  await fs.promises.writeFile(
+    /* turbopackIgnore: true */ getPosterPath(fileName),
+    bytes
+  );
 }
 
 export async function deleteShowPoster(fileName?: string) {
@@ -53,8 +68,8 @@ export async function deleteShowPoster(fileName?: string) {
   }
 
   const filePath = getPosterPath(fileName);
-  if (fs.existsSync(filePath)) {
-    await fs.promises.unlink(filePath);
+  if (fs.existsSync(/* turbopackIgnore: true */ filePath)) {
+    await fs.promises.unlink(/* turbopackIgnore: true */ filePath);
   }
 }
 
@@ -72,9 +87,9 @@ export function readShowPoster(fileName: string) {
   const normalizedFileName = sanitizePosterFileName(fileName);
   const filePath = getPosterPath(normalizedFileName);
 
-  if (!fs.existsSync(filePath)) {
+  if (!fs.existsSync(/* turbopackIgnore: true */ filePath)) {
     return null;
   }
 
-  return fs.readFileSync(filePath);
+  return fs.readFileSync(/* turbopackIgnore: true */ filePath);
 }

--- a/lib/shows-db.ts
+++ b/lib/shows-db.ts
@@ -35,6 +35,8 @@ type GalleryImageRow = {
   file_name: string;
   title: string;
   byte_size: number;
+  preview_file_name: string | null;
+  preview_byte_size: number | null;
   created_at: string;
 };
 
@@ -188,6 +190,27 @@ function migrateShowIds(db: Database.Database) {
   }
 }
 
+function migrateGalleryImagePreviews(db: Database.Database) {
+  const columns = db
+    .prepare("PRAGMA table_info(gallery_images);")
+    .all() as { name: string }[];
+  const columnNames = new Set(columns.map((column) => column.name));
+
+  if (!columnNames.has("preview_file_name")) {
+    db.exec("ALTER TABLE gallery_images ADD COLUMN preview_file_name TEXT;");
+  }
+
+  if (!columnNames.has("preview_byte_size")) {
+    db.exec("ALTER TABLE gallery_images ADD COLUMN preview_byte_size INTEGER;");
+  }
+
+  db.exec(`
+    CREATE UNIQUE INDEX IF NOT EXISTS gallery_images_preview_file_name
+    ON gallery_images(preview_file_name)
+    WHERE preview_file_name IS NOT NULL;
+  `);
+}
+
 function getDatabase() {
   if (database) {
     return database;
@@ -205,9 +228,12 @@ function getDatabase() {
       file_name TEXT NOT NULL UNIQUE,
       title TEXT NOT NULL,
       byte_size INTEGER NOT NULL,
+      preview_file_name TEXT,
+      preview_byte_size INTEGER,
       created_at TEXT NOT NULL
     );
   `);
+  migrateGalleryImagePreviews(db);
   db.exec(`
     CREATE TABLE IF NOT EXISTS gallery_videos (
       id TEXT PRIMARY KEY,
@@ -232,6 +258,9 @@ function mapGalleryImageRow(row: GalleryImageRow): GalleryImage {
     title: row.title,
     src: getGalleryImageSrc(row.file_name),
     byteSize: row.byte_size,
+    previewFileName: row.preview_file_name ?? undefined,
+    previewSrc: getGalleryImageSrc(row.preview_file_name ?? undefined),
+    previewByteSize: row.preview_byte_size ?? undefined,
     createdAt: row.created_at
   };
 }
@@ -382,6 +411,8 @@ export function getManagedGalleryImages(): GalleryImage[] {
           file_name,
           title,
           byte_size,
+          preview_file_name,
+          preview_byte_size,
           created_at
         FROM gallery_images
         ORDER BY created_at DESC, file_name ASC;
@@ -425,6 +456,8 @@ export function getManagedGalleryImageById(id: string): GalleryImage | null {
           file_name,
           title,
           byte_size,
+          preview_file_name,
+          preview_byte_size,
           created_at
         FROM gallery_images
         WHERE id = ?;
@@ -455,7 +488,7 @@ export function getGalleryPhotosFromDatabase(): MediaItem[] {
         id: image.id,
         type: "image" as const,
         title: image.title,
-        src: image.src,
+        src: image.previewSrc ?? image.src,
         link: image.src,
         alt: image.title
       }))
@@ -483,12 +516,16 @@ export function insertGalleryImage({
   fileName,
   title,
   byteSize,
+  previewFileName,
+  previewByteSize,
   createdAt
 }: {
   id: string;
   fileName: string;
   title: string;
   byteSize: number;
+  previewFileName: string;
+  previewByteSize: number;
   createdAt: string;
 }) {
   const db = getDatabase();
@@ -500,10 +537,39 @@ export function insertGalleryImage({
         file_name,
         title,
         byte_size,
+        preview_file_name,
+        preview_byte_size,
         created_at
-      ) VALUES (?, ?, ?, ?, ?);
+      ) VALUES (?, ?, ?, ?, ?, ?, ?);
     `
-  ).run(id, fileName, title, byteSize, createdAt);
+  ).run(
+    id,
+    fileName,
+    title,
+    byteSize,
+    previewFileName,
+    previewByteSize,
+    createdAt
+  );
+}
+
+export function updateGalleryImagePreview(
+  id: string,
+  previewFileName: string,
+  previewByteSize: number
+) {
+  const db = getDatabase();
+  const result = db
+    .prepare(
+      `
+        UPDATE gallery_images
+        SET preview_file_name = ?, preview_byte_size = ?
+        WHERE id = ?;
+      `
+    )
+    .run(previewFileName, previewByteSize, id.trim());
+
+  return result.changes > 0;
 }
 
 export function deleteGalleryImage(id: string) {

--- a/lib/shows-db.ts
+++ b/lib/shows-db.ts
@@ -53,7 +53,10 @@ type GalleryVideoRow = {
 
 const dataDir = path.join(process.cwd(), "data");
 const databasePath = process.env.SHOWS_DB_PATH?.trim()
-  ? path.resolve(process.cwd(), process.env.SHOWS_DB_PATH.trim())
+  ? path.resolve(
+      /* turbopackIgnore: true */ process.cwd(),
+      process.env.SHOWS_DB_PATH.trim()
+    )
   : path.join(dataDir, "shows.sqlite");
 
 let database: Database.Database | null = null;
@@ -216,7 +219,9 @@ function getDatabase() {
     return database;
   }
 
-  fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+  fs.mkdirSync(/* turbopackIgnore: true */ path.dirname(databasePath), {
+    recursive: true
+  });
   const db = new Database(databasePath);
   db.exec("PRAGMA journal_mode = WAL;");
   db.exec("PRAGMA synchronous = NORMAL;");

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -68,6 +68,9 @@ export type GalleryImage = {
   title: string;
   src?: string;
   byteSize: number;
+  previewFileName?: string;
+  previewSrc?: string;
+  previewByteSize?: number;
   createdAt: string;
 };
 

--- a/lib/video-thumbnail-files.ts
+++ b/lib/video-thumbnail-files.ts
@@ -6,17 +6,26 @@ function getVideoThumbnailsDir() {
 
   if (configuredDatabasePath) {
     const absoluteDatabasePath = path.resolve(
-      process.cwd(),
+      /* turbopackIgnore: true */ process.cwd(),
       configuredDatabasePath
     );
-    return path.join(path.dirname(absoluteDatabasePath), "video-thumbnails");
+    return path.join(
+      /* turbopackIgnore: true */ path.dirname(absoluteDatabasePath),
+      "video-thumbnails"
+    );
   }
 
-  return path.join(process.cwd(), "storage", "video-thumbnails");
+  return path.join(
+    /* turbopackIgnore: true */ process.cwd(),
+    "storage",
+    "video-thumbnails"
+  );
 }
 
 function ensureVideoThumbnailsDir() {
-  fs.mkdirSync(getVideoThumbnailsDir(), { recursive: true });
+  fs.mkdirSync(/* turbopackIgnore: true */ getVideoThumbnailsDir(), {
+    recursive: true
+  });
 }
 
 function normalizeVideoThumbnailFileName(fileName: string) {
@@ -25,7 +34,7 @@ function normalizeVideoThumbnailFileName(fileName: string) {
 
 function getVideoThumbnailPath(fileName: string) {
   return path.join(
-    getVideoThumbnailsDir(),
+    /* turbopackIgnore: true */ getVideoThumbnailsDir(),
     normalizeVideoThumbnailFileName(fileName)
   );
 }
@@ -38,7 +47,7 @@ export function getVideoThumbnailSrc(fileName?: string): string | undefined {
   const normalizedFileName = normalizeVideoThumbnailFileName(fileName);
   const filePath = getVideoThumbnailPath(normalizedFileName);
 
-  if (!fs.existsSync(filePath)) {
+  if (!fs.existsSync(/* turbopackIgnore: true */ filePath)) {
     return undefined;
   }
 
@@ -50,7 +59,10 @@ export async function saveVideoThumbnailFile(
   bytes: Uint8Array
 ) {
   ensureVideoThumbnailsDir();
-  await fs.promises.writeFile(getVideoThumbnailPath(fileName), bytes);
+  await fs.promises.writeFile(
+    /* turbopackIgnore: true */ getVideoThumbnailPath(fileName),
+    bytes
+  );
 }
 
 export async function deleteVideoThumbnailFile(fileName?: string) {
@@ -59,8 +71,8 @@ export async function deleteVideoThumbnailFile(fileName?: string) {
   }
 
   const filePath = getVideoThumbnailPath(fileName);
-  if (fs.existsSync(filePath)) {
-    await fs.promises.unlink(filePath);
+  if (fs.existsSync(/* turbopackIgnore: true */ filePath)) {
+    await fs.promises.unlink(/* turbopackIgnore: true */ filePath);
   }
 }
 
@@ -86,9 +98,9 @@ export function readVideoThumbnailFile(fileName: string) {
   const normalizedFileName = sanitizeVideoThumbnailFileName(fileName);
   const filePath = getVideoThumbnailPath(normalizedFileName);
 
-  if (!fs.existsSync(filePath)) {
+  if (!fs.existsSync(/* turbopackIgnore: true */ filePath)) {
     return null;
   }
 
-  return fs.readFileSync(filePath);
+  return fs.readFileSync(/* turbopackIgnore: true */ filePath);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "lucide-react": "^0.563.0",
         "next": "^16.2.10",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "sharp": "^0.34.5"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
@@ -531,7 +532,6 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -6081,7 +6081,6 @@
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -6125,7 +6124,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lucide-react": "^0.563.0",
     "next": "^16.2.10",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "sharp": "^0.34.5"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",


### PR DESCRIPTION
- Generate 1,200px WebP previews at upload time using Sharp
- Store original and preview metadata in SQLite
- Use previews for gallery and admin thumbnails
- Preserve original JPEGs for the lightbox
- Backfill previews for existing photos with safe fallback behavior
- Delete both image versions together
- Fix Turbopack tracing warnings for runtime storage paths